### PR TITLE
Adding AML pipeline for running non-python tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 # Azure Subscription Variables
+# For executing from devcontainer login with az-cli instead
+# az login --service-principal -u <SP_APP_ID> -p <SP_APP_SECRET> --tenant <TENANT_ID>
 SUBSCRIPTION_ID = ''
 LOCATION = ''
 TENANT_ID = ''
@@ -55,3 +57,9 @@ AML_REBUILD_ENVIRONMENT = 'false'
 # Smoke test image URLs and Classes separated by comma
 TEST_IMAGE_URLS = 'url_to_sunflowers,url_to_daisy'
 TEST_IMAGE_CLASSES = 'sunflowers,daisy'
+
+# Processing OS cmd on custom docker image
+AML_CUSTOM_DOCKER_ENV_NAME = 'custom_docker_env'
+AML_CUSTOM_DOCKERFILE = 'ml_model/preprocessing/Dockerfile'
+PREPROCESS_OS_CMD_SCRIPT_PATH = 'preprocessing/preprocess_os_cmd.py'
+PREPROCESSING_OS_CMD_PIPELINE_NAME = 'custom-data-processing-pipeline'

--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ TEST_IMAGE_URLS = 'url_to_sunflowers,url_to_daisy'
 TEST_IMAGE_CLASSES = 'sunflowers,daisy'
 
 # Processing OS cmd on custom docker image
-AML_CUSTOM_DOCKER_ENV_NAME = 'custom_docker_env'
-AML_CUSTOM_DOCKERFILE = 'ml_model/preprocessing/Dockerfile'
-PREPROCESS_OS_CMD_SCRIPT_PATH = 'preprocessing/preprocess_os_cmd.py'
+AML_PREPROCESSING_CUSTOM_DOCKER_ENV_NAME = 'custom_docker_env'
+AML_PREPROCESSING_CUSTOM_DOCKERFILE = 'ml_model/preprocessing/Dockerfile'
+PREPROCESSING_OS_CMD_SCRIPT_PATH = 'preprocessing/preprocess_os_cmd.py'
 PREPROCESSING_OS_CMD_PIPELINE_NAME = 'custom-data-processing-pipeline'

--- a/.pipelines/02-processing-data.yml
+++ b/.pipelines/02-processing-data.yml
@@ -54,4 +54,4 @@ stages:
 # Trigger_Preprocessing_Pipeline
 - template: trigger-preprocessing-pipeline.yml
   parameters:
-    pipeline_name: $(PREPROCESSING_PIPELINE_NAME)
+    aml_pipeline_name: $(PREPROCESSING_PIPELINE_NAME)

--- a/.pipelines/02-processing-data.yml
+++ b/.pipelines/02-processing-data.yml
@@ -54,8 +54,9 @@ stages:
 # Trigger_Preprocessing_Pipeline
 - template: trigger-preprocessing-pipeline.yml
   parameters:
-    aml_pipeline_name: ${{ variable.PREPROCESSING_PIPELINE_NAME }}
-    # aml_pipeline_name: 'flower-data-processing-pipeline'
+    # Template parameters can not be expanded, hard coded here
+    aml_pipeline_name: 'flower-data-processing-pipeline'
+    # aml_pipeline_name: ${{ variable.PREPROCESSING_PIPELINE_NAME }}
     # aml_pipeline_name: $(PREPROCESSING_PIPELINE_NAME)
     # Variable expanding for Parameters is not always possible:
     # https://developercommunity.visualstudio.com/content/problem/429990/azure-pipelines-passing-a-variable-as-a-parameter.html

--- a/.pipelines/02-processing-data.yml
+++ b/.pipelines/02-processing-data.yml
@@ -51,44 +51,7 @@ stages:
           python -m ml_service.pipelines.build_data_processing_pipeline
       displayName: 'Publish Data Preprocessing Pipeline'
 
-- stage: 'Trigger_Preprocessing_Pipeline'
-  displayName: 'Preprocess data'
-  condition: succeeded()
-  variables:
-    BUILD_URI: '$(SYSTEM.COLLECTIONURI)$(SYSTEM.TEAMPROJECT)/_build/results?buildId=$(BUILD.BUILDID)'
-  jobs:
-  - job: "Get_Preprocessing_Pipeline_ID"
-    condition: and(succeeded(), eq(coalesce(variables['auto-preprocess-data'], 'true'), 'true'))
-    displayName: "Get Preprocessing Pipeline ID for execution"
-    container: mlops
-    timeoutInMinutes: 0
-    steps:
-    - task: AzureCLI@1
-      inputs:
-        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
-        scriptLocation: inlineScript
-        workingDirectory: $(Build.SourcesDirectory)
-        inlineScript: |
-          set -e # fail on error
-          export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-          python -m ml_service.pipelines.run_data_processing_pipeline --output_pipeline_id_file "preprocessing_pipeline_id.txt" --skip_preprocessing_execution
-          # Set AMLPIPELINEID variable for next AML Pipeline task in next job
-          PREPROCESSPIPELINEID="$(cat preprocessing_pipeline_id.txt)"
-          echo "##vso[task.setvariable variable=PREPROCESSPIPELINEID;isOutput=true]$PREPROCESSPIPELINEID"
-      name: 'getpreprocessingpipelineid'
-      displayName: 'Get Preprocessing Pipeline ID'
-  - job: "Run_Data_Processing_Pipeline"
-    dependsOn: "Get_Preprocessing_Pipeline_ID"
-    displayName: "Trigger Preprocessing Pipeline"
-    timeoutInMinutes: 0
-    pool: server
-    variables:
-      PREPROCESSPIPELINE_ID: $[ dependencies.Get_Preprocessing_Pipeline_ID.outputs['getpreprocessingpipelineid.PREPROCESSPIPELINEID'] ]
-    steps:
-    - task: ms-air-aiagility.vss-services-azureml.azureml-restApi-task.MLPublishedPipelineRestAPITask@0
-      displayName: 'Invoke Preprocessing pipeline'
-      inputs:
-        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
-        PipelineId: '$(PREPROCESSPIPELINE_ID)'
-        ExperimentName: '$(EXPERIMENT_NAME)_preprocess'
-        PipelineParameters: '"ParameterAssignments": {"data_file_path": "$(RAW_DATAFILE_PATH)", "preprocessing_param": "$(PREPROCESSING_PARAM)"}, "tags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}, "StepTags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}'
+# Trigger_Preprocessing_Pipeline
+- template: trigger-preprocessing-pipeline.yml
+  parameters:
+    pipeline_name: $(PREPROCESSING_PIPELINE_NAME)

--- a/.pipelines/02-processing-data.yml
+++ b/.pipelines/02-processing-data.yml
@@ -19,6 +19,7 @@ trigger:
     - .pipelines/02-processing-data.yml
     - .pipelines/variables-template.yml
     - .pipelines/code-quality-template.yml
+    - .pipelines/trigger-preprocessing-pipeline.yml
 
 
 variables:

--- a/.pipelines/02-processing-data.yml
+++ b/.pipelines/02-processing-data.yml
@@ -54,4 +54,8 @@ stages:
 # Trigger_Preprocessing_Pipeline
 - template: trigger-preprocessing-pipeline.yml
   parameters:
-    aml_pipeline_name: $(PREPROCESSING_PIPELINE_NAME)
+    aml_pipeline_name: ${{ variable.PREPROCESSING_PIPELINE_NAME }}
+    # aml_pipeline_name: 'flower-data-processing-pipeline'
+    # aml_pipeline_name: $(PREPROCESSING_PIPELINE_NAME)
+    # Variable expanding for Parameters is not always possible:
+    # https://developercommunity.visualstudio.com/content/problem/429990/azure-pipelines-passing-a-variable-as-a-parameter.html

--- a/.pipelines/02-processing-data.yml
+++ b/.pipelines/02-processing-data.yml
@@ -55,7 +55,7 @@ stages:
 - template: trigger-preprocessing-pipeline.yml
   parameters:
     # Template parameters can not be expanded, hard coded here
-    aml_pipeline_name: 'flower-data-processing-pipeline'
+    aml_pipeline_name: 'flower-preprocessing-pipeline'
     # aml_pipeline_name: ${{ variable.PREPROCESSING_PIPELINE_NAME }}
     # aml_pipeline_name: $(PREPROCESSING_PIPELINE_NAME)
     # Variable expanding for Parameters is not always possible:

--- a/.pipelines/06-validate-custom-amlstep-dockerfile.yml
+++ b/.pipelines/06-validate-custom-amlstep-dockerfile.yml
@@ -1,0 +1,18 @@
+# For build validation of custom preprocessing aml pipeline step compatible Dockerfile
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - ml_model/preprocessing/Dockerfile
+    
+jobs:
+  - job: buildAmlPipelineCompContainer
+    displayName: 'Docker build validation aml pipeline compatible step'
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - script: docker build -f Dockerfile .
+      workingDirectory: $(Build.SourcesDirectory)/ml_model/preprocessing/
+      displayName: 'Copy first level contents only to ArtifactStagingDirectory'

--- a/.pipelines/06-validate-custom-amlstep-dockerfile.yml
+++ b/.pipelines/06-validate-custom-amlstep-dockerfile.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - script: docker build -f Dockerfile .
       workingDirectory: $(Build.SourcesDirectory)/ml_model/preprocessing/
-      displayName: 'Copy first level contents only to ArtifactStagingDirectory'
+      displayName: 'Docker build validation aml pipeline compatible step'

--- a/.pipelines/07-processing-data-os-cmd.yml
+++ b/.pipelines/07-processing-data-os-cmd.yml
@@ -19,6 +19,7 @@ trigger:
     - .pipelines/07-processing-data-os-cmd.yml
     - .pipelines/variables-template.yml
     - .pipelines/code-quality-template.yml
+    - .pipelines/trigger-preprocessing-pipeline.yml
 
 
 variables:

--- a/.pipelines/07-processing-data-os-cmd.yml
+++ b/.pipelines/07-processing-data-os-cmd.yml
@@ -1,0 +1,57 @@
+# Continuous Integration (CI) pipeline that orchestrates the training, evaluation, and registration of the model.
+
+resources:
+  containers:
+  - container: mlops
+    image: public/mlops/tensorflow:latest
+    endpoint: mlopstensorflowacr
+
+pr: none
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - ml_model/preprocessing/Dockerfile
+    - ml_model/preprocessing/preprocess_os_cmd.py
+    - ml_service/pipelines/build_data_processing_os_cmd_pipeline.py
+    - .pipelines/07-processing-data-os-cmd.yml
+    - .pipelines/variables-template.yml
+    - .pipelines/code-quality-template.yml
+
+
+variables:
+- template: variables-template.yml
+- group: devopsforai-aml-vg
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+- stage: 'Data_CI'
+  displayName: 'Data code quality and publish preprocessing pipeline'
+  jobs:
+  - job: "Data_CI_Pipeline"
+    displayName: "Data CI Pipeline"
+    container: mlops
+    timeoutInMinutes: 0
+    steps:
+    - template: code-quality-template.yml
+    - task: AzureCLI@1
+      enabled: true
+      inputs:
+        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
+        scriptLocation: inlineScript
+        workingDirectory: $(Build.SourcesDirectory)
+        inlineScript: |
+          set -e # fail on error
+          export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+          # Invoke the Python building and publishing a data preprocessing pipeline
+          python -m ml_service.pipelines.build_data_processing_os_cmd_pipeline
+      displayName: 'Publish Data Preprocessing OS cmd Pipeline'
+
+# Trigger_Preprocessing_Pipeline
+- template: trigger-preprocessing-pipeline.yml
+  parameters:
+    pipeline_name: $(PREPROCESSING_OS_CMD_PIPELINE_NAME)

--- a/.pipelines/07-processing-data-os-cmd.yml
+++ b/.pipelines/07-processing-data-os-cmd.yml
@@ -54,4 +54,4 @@ stages:
 # Trigger_Preprocessing_Pipeline
 - template: trigger-preprocessing-pipeline.yml
   parameters:
-    pipeline_name: $(PREPROCESSING_OS_CMD_PIPELINE_NAME)
+    aml_pipeline_name: $(PREPROCESSING_OS_CMD_PIPELINE_NAME)

--- a/.pipelines/07-processing-data-os-cmd.yml
+++ b/.pipelines/07-processing-data-os-cmd.yml
@@ -54,8 +54,9 @@ stages:
 # Trigger_Preprocessing_Pipeline
 - template: trigger-preprocessing-pipeline.yml
   parameters:
-    aml_pipeline_name: ${{ variable.PREPROCESSING_OS_CMD_PIPELINE_NAME }}
-    # aml_pipeline_name: 'custom-data-processing-pipeline'
+    # Template parameters can not be expanded, hard coded here
+    aml_pipeline_name: 'custom-data-processing-pipeline'
+    # aml_pipeline_name: ${{ variable.PREPROCESSING_OS_CMD_PIPELINE_NAME }}
     # aml_pipeline_name: $(PREPROCESSING_OS_CMD_PIPELINE_NAME)
     # Variable expanding for Parameters is not always possible:
     # https://developercommunity.visualstudio.com/content/problem/429990/azure-pipelines-passing-a-variable-as-a-parameter.html

--- a/.pipelines/07-processing-data-os-cmd.yml
+++ b/.pipelines/07-processing-data-os-cmd.yml
@@ -54,4 +54,8 @@ stages:
 # Trigger_Preprocessing_Pipeline
 - template: trigger-preprocessing-pipeline.yml
   parameters:
-    aml_pipeline_name: $(PREPROCESSING_OS_CMD_PIPELINE_NAME)
+    aml_pipeline_name: ${{ variable.PREPROCESSING_OS_CMD_PIPELINE_NAME }}
+    # aml_pipeline_name: 'custom-data-processing-pipeline'
+    # aml_pipeline_name: $(PREPROCESSING_OS_CMD_PIPELINE_NAME)
+    # Variable expanding for Parameters is not always possible:
+    # https://developercommunity.visualstudio.com/content/problem/429990/azure-pipelines-passing-a-variable-as-a-parameter.html

--- a/.pipelines/trigger-preprocessing-pipeline.yml
+++ b/.pipelines/trigger-preprocessing-pipeline.yml
@@ -43,5 +43,5 @@ stages:
       inputs:
         azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
         PipelineId: '$(PREPROCESSPIPELINE_ID)'
-        ExperimentName: '$(EXPERIMENT_NAME)'
-        PipelineParameters: '"tags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}, "StepTags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}'
+        ExperimentName: '$(EXPERIMENT_NAME)_preprocess'
+        PipelineParameters: '"ParameterAssignments": {"data_file_path": "$(RAW_DATAFILE_PATH)", "preprocessing_param": "$(PREPROCESSING_PARAM)"}, "tags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}, "StepTags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}'

--- a/.pipelines/trigger-preprocessing-pipeline.yml
+++ b/.pipelines/trigger-preprocessing-pipeline.yml
@@ -1,0 +1,47 @@
+parameters:
+  - name: pipeline_name
+    displayName: Pipeline Name to trigger
+    type: string
+
+stages:
+- stage: 'Trigger_Preprocessing_Pipeline ${{ parameters.pipeline_name }}'
+  displayName: 'Preprocess data'
+  condition: succeeded()
+  variables:
+    BUILD_URI: '$(SYSTEM.COLLECTIONURI)$(SYSTEM.TEAMPROJECT)/_build/results?buildId=$(BUILD.BUILDID)'
+  jobs:
+  - job: "Get_Preprocessing_Pipeline_ID"
+    condition: and(succeeded(), eq(coalesce(variables['auto-preprocess-data'], 'true'), 'true'))
+    displayName: "Get Preprocessing Pipeline ID for execution of ${{ parameters.pipeline_name }}"
+    container: mlops
+    timeoutInMinutes: 0
+    steps:
+    - task: AzureCLI@1
+      inputs:
+        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
+        scriptLocation: inlineScript
+        workingDirectory: $(Build.SourcesDirectory)
+        inlineScript: |
+          set -e # fail on error
+          export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+          python -m ml_service.pipelines.run_data_processing_pipeline --aml_pipeline_name ${{ parameters.pipeline_name }} --output_pipeline_id_file "preprocessing_pipeline_id.txt" --skip_preprocessing_execution
+          # Set AMLPIPELINEID variable for next AML Pipeline task in next job
+          PREPROCESSPIPELINEID="$(cat preprocessing_pipeline_id.txt)"
+          echo "##vso[task.setvariable variable=PREPROCESSPIPELINEID;isOutput=true]$PREPROCESSPIPELINEID"
+      name: 'getpreprocessingpipelineid'
+      displayName: 'Get Preprocessing Pipeline ID of ${{ parameters.pipeline_name }}'
+  - job: "Run_Data_Processing_Pipeline"
+    dependsOn: "Get_Preprocessing_Pipeline_ID"
+    displayName: "Trigger Preprocessing Pipeline ${{ parameters.pipeline_name }}"
+    timeoutInMinutes: 0
+    pool: server
+    variables:
+      PREPROCESSPIPELINE_ID: $[ dependencies.Get_Preprocessing_Pipeline_ID.outputs['getpreprocessingpipelineid.PREPROCESSPIPELINEID'] ]
+    steps:
+    - task: ms-air-aiagility.vss-services-azureml.azureml-restApi-task.MLPublishedPipelineRestAPITask@0
+      displayName: 'Invoke Preprocessing pipeline ${{ parameters.pipeline_name }}'
+      inputs:
+        azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
+        PipelineId: '$(PREPROCESSPIPELINE_ID)'
+        ExperimentName: '$(EXPERIMENT_NAME)'
+        PipelineParameters: '"tags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}, "StepTags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}'

--- a/.pipelines/trigger-preprocessing-pipeline.yml
+++ b/.pipelines/trigger-preprocessing-pipeline.yml
@@ -4,8 +4,8 @@ parameters:
     type: string
 
 stages:
-- stage: 'Trigger_Preprocessing_Pipeline ${{ parameters.aml_pipeline_name }}'
-  displayName: 'Preprocess data'
+- stage: 'Trigger_Preprocessing_Pipeline'
+  displayName: 'Preprocess data ${{ parameters.aml_pipeline_name }}'
   condition: succeeded()
   variables:
     BUILD_URI: '$(SYSTEM.COLLECTIONURI)$(SYSTEM.TEAMPROJECT)/_build/results?buildId=$(BUILD.BUILDID)'

--- a/.pipelines/trigger-preprocessing-pipeline.yml
+++ b/.pipelines/trigger-preprocessing-pipeline.yml
@@ -1,10 +1,10 @@
 parameters:
-  - name: pipeline_name
-    displayName: Pipeline Name to trigger
+  - name: aml_pipeline_name
+    displayName: AML Pipeline Name to trigger
     type: string
 
 stages:
-- stage: 'Trigger_Preprocessing_Pipeline ${{ parameters.pipeline_name }}'
+- stage: 'Trigger_Preprocessing_Pipeline ${{ parameters.aml_pipeline_name }}'
   displayName: 'Preprocess data'
   condition: succeeded()
   variables:
@@ -12,7 +12,7 @@ stages:
   jobs:
   - job: "Get_Preprocessing_Pipeline_ID"
     condition: and(succeeded(), eq(coalesce(variables['auto-preprocess-data'], 'true'), 'true'))
-    displayName: "Get Preprocessing Pipeline ID for execution of ${{ parameters.pipeline_name }}"
+    displayName: "Get Preprocessing Pipeline ID for execution of ${{ parameters.aml_pipeline_name }}"
     container: mlops
     timeoutInMinutes: 0
     steps:
@@ -24,22 +24,22 @@ stages:
         inlineScript: |
           set -e # fail on error
           export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-          python -m ml_service.pipelines.run_data_processing_pipeline --aml_pipeline_name ${{ parameters.pipeline_name }} --output_pipeline_id_file "preprocessing_pipeline_id.txt" --skip_preprocessing_execution
+          python -m ml_service.pipelines.run_data_processing_pipeline --aml_pipeline_name ${{ parameters.aml_pipeline_name }} --output_pipeline_id_file "preprocessing_pipeline_id.txt" --skip_preprocessing_execution
           # Set AMLPIPELINEID variable for next AML Pipeline task in next job
           PREPROCESSPIPELINEID="$(cat preprocessing_pipeline_id.txt)"
           echo "##vso[task.setvariable variable=PREPROCESSPIPELINEID;isOutput=true]$PREPROCESSPIPELINEID"
       name: 'getpreprocessingpipelineid'
-      displayName: 'Get Preprocessing Pipeline ID of ${{ parameters.pipeline_name }}'
+      displayName: 'Get Preprocessing Pipeline ID of ${{ parameters.aml_pipeline_name }}'
   - job: "Run_Data_Processing_Pipeline"
     dependsOn: "Get_Preprocessing_Pipeline_ID"
-    displayName: "Trigger Preprocessing Pipeline ${{ parameters.pipeline_name }}"
+    displayName: "Trigger Preprocessing Pipeline ${{ parameters.aml_pipeline_name }}"
     timeoutInMinutes: 0
     pool: server
     variables:
       PREPROCESSPIPELINE_ID: $[ dependencies.Get_Preprocessing_Pipeline_ID.outputs['getpreprocessingpipelineid.PREPROCESSPIPELINEID'] ]
     steps:
     - task: ms-air-aiagility.vss-services-azureml.azureml-restApi-task.MLPublishedPipelineRestAPITask@0
-      displayName: 'Invoke Preprocessing pipeline ${{ parameters.pipeline_name }}'
+      displayName: 'Invoke Preprocessing pipeline ${{ parameters.aml_pipeline_name }}'
       inputs:
         azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
         PipelineId: '$(PREPROCESSPIPELINE_ID)'

--- a/.pipelines/variables-template.yml
+++ b/.pipelines/variables-template.yml
@@ -33,6 +33,8 @@ variables:
     value: flower_dataset
   - name: PREPROCESSING_PIPELINE_NAME
     value: "flower-preprocessing-pipeline"
+  - name: PREPROCESSING_OS_CMD_PIPELINE_NAME
+    value: "custom-data-processing-pipeline"
   - name: TRAINING_PIPELINE_NAME
     value: "flower-training-Pipeline"
   - name: MODEL_NAME

--- a/.pipelines/variables-template.yml
+++ b/.pipelines/variables-template.yml
@@ -19,6 +19,9 @@ variables:
     # The path to the model scoring script relative to SOURCES_DIR_TRAIN
   - name: SCORE_SCRIPT
     value: scoring/score.py
+    # The path to the data os cmd preprocessing script under SOURCES_DIR_TRAIN
+  - name: PREPROCESSING_OS_CMD_SCRIPT_PATH
+    value: preprocessing/preprocess_os_cmd.py
     
   # Azure ML Variables
   - name: EXPERIMENT_NAME
@@ -40,11 +43,17 @@ variables:
   - name: MODEL_NAME
     value: flower_classifier
 
-  # AML Compute Cluster Config
+  # AML Environment Config
   - name: AML_ENV_NAME
     value: flower_classifier_training_env
   - name: AML_ENV_TRAIN_CONDA_DEP_FILE
     value: "conda_dependencies.yml"
+  - name: AML_PREPROCESSING_CUSTOM_DOCKER_ENV_NAME
+    value: flower_custom_preprocess_env
+  - name: AML_PREPROCESSING_CUSTOM_DOCKERFILE
+    value: ml_model/preprocessing/Dockerfile
+
+  # AML Compute Cluster Config
   - name: AML_COMPUTE_CLUSTER_CPU_SKU
     value: STANDARD_DS2_V2
   - name: AML_COMPUTE_CLUSTER_NAME

--- a/.pipelines/variables-template.yml
+++ b/.pipelines/variables-template.yml
@@ -87,5 +87,5 @@ variables:
     value: "false"
 
   # Flag to allow rebuilding the AML Environment after it was built for the first time. This enables dependency updates from conda_dependencies.yaml.
-  # - name: AML_REBUILD_ENVIRONMENT
-  #  value: "false"
+  - name: AML_REBUILD_ENVIRONMENT
+    value: "true"

--- a/ml_model/preprocessing/Dockerfile
+++ b/ml_model/preprocessing/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:16.04
+
+ARG CONDA_VERSION=4.7.12
+ARG PYTHON_VERSION=3.7
+ARG AZUREML_SDK_VERSION=1.13.0
+ARG INFERENCE_SCHEMA_VERSION=1.1.0
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/miniconda/bin:$PATH
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --fix-missing && \
+    apt-get install -y wget bzip2 && \
+    apt-get install -y fuse && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home dockeruser
+WORKDIR /home/dockeruser
+USER dockeruser
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p ~/miniconda && \
+    rm ~/miniconda.sh && \
+    ~/miniconda/bin/conda clean -tipsy
+ENV PATH="/home/dockeruser/miniconda/bin/:${PATH}"
+
+RUN conda install -y conda=${CONDA_VERSION} python=${PYTHON_VERSION} && \
+    pip install azureml-defaults==${AZUREML_SDK_VERSION} inference-schema==${INFERENCE_SCHEMA_VERSION} &&\
+    conda clean -aqy && \
+    rm -rf ~/miniconda/pkgs && \
+    find ~/miniconda/ -type d -name __pycache__ -prune -exec rm -rf {} \;

--- a/ml_model/preprocessing/README.md
+++ b/ml_model/preprocessing/README.md
@@ -1,0 +1,99 @@
+# Data Preprocessing
+
+This folder contains samples and templates for data preprocessing steps with
+Azure Machine Learning Pipelines.
+
+## Explaining data preprocessing with non-python tooling for AML
+
+The [wrapper script](./preprocess_os_cmd.py) calls the command line command.
+In the basic sample it is just a `cp` to move data from
+the input folder to the output folder of it's AML pipeline step.
+
+```python
+    process = subprocess.Popen(['cp',
+                                '{0}/.'.format(mount_context.mount_point),
+                                step_output_path, '-r', '-v'],
+                               stdout=subprocess.PIPE,
+                               universal_newlines=True)
+```
+
+So it is possible to call any tool or program which can be executed on a ubuntu
+linux (which is the base image for AML pipeline steps).
+The tool(s) need to be installed in the [custom container image](./Dockerfile).
+
+Important to know is that the input folder is getting mounted within the wrapper script here, so you can only work on
+the data after this code:
+
+```python
+    mount_context = dataset.mount()
+    mount_context.start()
+    print(f"mount_point is: {mount_context.mount_point}")
+```
+
+The mount point or folder is stored in this attribute
+`mount_context.mount_point` and can be used in the command line call.
+As well as the output folder path for this step which is stored in `step_output_path`.
+
+## Example: Setup image preprocessing with ImageMagick
+
+As an example on how to extend this template I will use this [blog post](https://vitux.com/how-to-resize-images-on-the-ubuntu-command-line/)
+about resizing images with [ImageMagick](https://imagemagick.org/index.php).
+
+1. Adding ImageMagick to the **Dockerfile** for the custom preprocessing step
+2. Change the command line call in the **Wrapper script**
+3. Rebuilding, publish and run the **data_processing_os_cmd_pipeline**
+
+### Adding ImageMagick to the Dockerfile for the custom preprocessing step
+
+Adding the installation instruction `apt-get install -y imagemagick && \` to the [Dockerfile](./Dockerfile)
+just before `apt-get clean` is called:
+
+```dockerfile
+RUN apt-get update --fix-missing && \
+    apt-get install -y wget bzip2 && \
+    apt-get install -y fuse && \
+    apt-get install -y imagemagick && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+### Change the command line call in the Wrapper script
+
+>Assumption: Input pictures are all jpg and output pictures should be 100x100.
+Input dataset is <http://download.tensorflow.org/example_images/flower_photos.tgz>,
+only convert the subfolder daisy will be resized.
+
+Changing the command to:
+
+```python
+    process = subprocess.Popen(['convert',
+                                '{0}/daisy/*.jpg'.format(mount_context.mount_point),
+                                '-resize',
+                                '100x100!',
+                                '{0}/resized.jpg'.format(step_output_path)],
+                               stdout=subprocess.PIPE,
+                               universal_newlines=True)
+```
+
+### Rebuilding, publish and run the data_processing_os_cmd_pipeline
+
+For local dev test the variable `AML_REBUILD_ENVIRONMENT` in `.env` file needs to be set to true.
+
+```bash
+# Flag to allow rebuilding the AML Environment after it was built for the first time. This enables dependency updates from conda_dependencies.yaml.
+AML_REBUILD_ENVIRONMENT = 'true'
+```
+
+If the local dev test is set up correct you can publish and execute the
+pipeline with following commands from project root folder:
+
+```bash
+python -m ml_service.pipelines.build_data_processing_os_cmd_pipeline
+```
+
+```bash
+python -m ml_service.pipelines.run_data_processing_pipeline --aml_pipeline_name "custom-data-processing-pipeline"
+```
+
+For stage and production you have to check in the code and run through
+review and AzDO pipeline process.

--- a/ml_model/preprocessing/preprocess_os_cmd.py
+++ b/ml_model/preprocessing/preprocess_os_cmd.py
@@ -33,13 +33,7 @@ def main():
     )
 
     parser.add_argument(
-        "--caller_run_id",
-        type=str,
-        help=("caller run id, for example ADF pipeline run id")
-    )
-
-    parser.add_argument(
-        "--step_output",
+        "--output_dataset",
         type=str,
         help=("output for passing data to next step")
     )
@@ -49,13 +43,12 @@ def main():
     print("Argument [dataset_name]: %s" % args.dataset_name)
     print("Argument [datastore_name]: %s" % args.datastore_name)
     print("Argument [data_file_path]: %s" % args.data_file_path)
-    print("Argument [caller_run_id]: %s" % args.caller_run_id)
-    print("Argument [step_output]: %s" % args.step_output)
+    print("Argument [output_dataset]: %s" % args.output_dataset)
 
     data_file_path = args.data_file_path
     dataset_name = args.dataset_name
     datastore_name = args.datastore_name
-    step_output_path = args.step_output
+    output_dataset_path = args.output_dataset
 
     run = Run.get_context()
 
@@ -71,7 +64,6 @@ def main():
 
     # Link dataset to the step run so it is trackable in the UI
     run.input_datasets['input_dataset'] = dataset
-    run.parent.tag("dataset_id", value=dataset.id)
 
     # Process data
     mount_context = dataset.mount()
@@ -85,7 +77,9 @@ def main():
     # in the docker image (ml_model/preprocessing/Dockerfile)
     process = subprocess.Popen(['cp',
                                 '{0}/.'.format(mount_context.mount_point),
-                                step_output_path, '-r', '-v'],
+                                output_dataset_path,
+                                '-r',
+                                '-v'],
                                stdout=subprocess.PIPE,
                                universal_newlines=True)
     # Check output

--- a/ml_model/preprocessing/preprocess_os_cmd.py
+++ b/ml_model/preprocessing/preprocess_os_cmd.py
@@ -1,0 +1,113 @@
+"""
+Copyright (C) Microsoft Corporation. All rights reserved.​
+"""
+from azureml.core.run import Run
+import argparse
+import subprocess
+from util.model_helper import get_or_register_dataset, get_aml_context
+
+
+def main():
+    print("Running preprocess_os_cmd.py")
+
+    parser = argparse.ArgumentParser("preprocess_os_cmd")
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        help=("Dataset name. Dataset must be passed by name\
+              to always get the desired dataset version\
+              rather than the one used while the pipeline creation")
+    )
+
+    parser.add_argument(
+        "--datastore_name",
+        type=str,
+        help=("Datastore name. If none, use the default datastore")
+    )
+
+    parser.add_argument(
+        "--data_file_path",
+        type=str,
+        help=("data file path, if specified,\
+               a new version of the dataset will be registered")
+    )
+
+    parser.add_argument(
+        "--caller_run_id",
+        type=str,
+        help=("caller run id, for example ADF pipeline run id")
+    )
+
+    parser.add_argument(
+        "--step_output",
+        type=str,
+        help=("output for passing data to next step")
+    )
+
+    args = parser.parse_args()
+
+    print("Argument [dataset_name]: %s" % args.dataset_name)
+    print("Argument [datastore_name]: %s" % args.datastore_name)
+    print("Argument [data_file_path]: %s" % args.data_file_path)
+    print("Argument [caller_run_id]: %s" % args.caller_run_id)
+    print("Argument [step_output]: %s" % args.step_output)
+
+    data_file_path = args.data_file_path
+    dataset_name = args.dataset_name
+    datastore_name = args.datastore_name
+    step_output_path = args.step_output
+
+    run = Run.get_context()
+
+    # Get Azure machine learning workspace
+    aml_workspace, *_ = get_aml_context(run)
+
+    # Get the dataset
+    dataset = get_or_register_dataset(
+        dataset_name,
+        datastore_name,
+        data_file_path,
+        aml_workspace)
+
+    # Link dataset to the step run so it is trackable in the UI
+    run.input_datasets['input_dataset'] = dataset
+    run.parent.tag("dataset_id", value=dataset.id)
+
+    # Process data
+    mount_context = dataset.mount()
+    mount_context.start()
+    print(f"mount_point is: {mount_context.mount_point}")
+
+    ####
+    # Execute something here just 'cp' from input to output folder
+    #   cp /tmp/. /tmp2 -r
+    # Prepackage any command line tools needed,
+    # in the docker image (ml_model/preprocessing/Dockerfile)
+    process = subprocess.Popen(['cp',
+                                '{0}/.'.format(mount_context.mount_point),
+                                step_output_path, '-r', '-v'],
+                               stdout=subprocess.PIPE,
+                               universal_newlines=True)
+    # Check output
+    while True:
+        output = process.stdout.readline()
+        print(output.strip())
+        # Do something else
+        return_code = process.poll()
+        if return_code is not None:
+            print('RETURN CODE', return_code)
+            # Process has finished, read rest of the output
+            for output in process.stdout.readlines():
+                print(output.strip())
+            break
+
+    mount_context.stop()
+
+    run.tag("run_type", value="preprocess_os_cmd")
+    print(f"tags now present for run: {run.tags}")
+
+    run.complete()
+
+
+if __name__ == '__main__':
+    main()

--- a/ml_service/pipelines/build_data_processing_os_cmd_pipeline.py
+++ b/ml_service/pipelines/build_data_processing_os_cmd_pipeline.py
@@ -43,7 +43,6 @@ def main():
 
     datastore = Datastore(aml_workspace, name=datastore_name)
     data_file_path_param = PipelineParameter(name="data_file_path", default_value=e.dataset_name)  # NOQA: E501
-    caller_run_id_param = PipelineParameter(name="caller_run_id", default_value="none")  # NOQA: E501
 
     # The version of the input/output dataset can't be determined at pipeline publish time, only run time.  # NOQA: E501
     # Options to store output data:
@@ -54,7 +53,7 @@ def main():
     # Option 2: Use a dynamic path in OutputFileDatasetConfig, and register a new dataset at completion  # NOQA: E501
     #     Output dataset can be mounted, so more dataset to maintain, less code.   # NOQA: E501
     # Using Option 2 below.
-    output_ds = OutputFileDatasetConfig(
+    output_dataset = OutputFileDatasetConfig(
         name=e.processed_dataset_name,
         destination=(datastore, "/dataset/{output-name}/{run-id}")
     ).register_on_complete(
@@ -69,8 +68,7 @@ def main():
             "--dataset_name", e.dataset_name,
             "--datastore_name", datastore_name,
             "--data_file_path", data_file_path_param,
-            "--caller_run_id", caller_run_id_param,
-            "--step_output", output_ds,
+            "--output_dataset", output_dataset,
         ],
         runconfig=run_config,
         allow_reuse=False,

--- a/ml_service/pipelines/build_data_processing_os_cmd_pipeline.py
+++ b/ml_service/pipelines/build_data_processing_os_cmd_pipeline.py
@@ -1,0 +1,94 @@
+from azureml.pipeline.core.graph import PipelineParameter
+from azureml.pipeline.steps import PythonScriptStep
+from azureml.pipeline.core import Pipeline
+from azureml.core import Workspace, Datastore
+from azureml.core.runconfig import RunConfiguration
+from azureml.data import OutputFileDatasetConfig
+from ml_service.util.attach_compute import get_compute
+from ml_service.util.env_variables import Env
+from ml_service.util.manage_environment import get_environment
+
+
+def main():
+    e = Env()
+    # Get Azure machine learning workspace
+    aml_workspace = Workspace.get(
+        name=e.workspace_name,
+        subscription_id=e.subscription_id,
+        resource_group=e.resource_group,
+    )
+    print(f"get_workspace:{aml_workspace}")
+
+    # Get Azure machine learning cluster
+    aml_compute = get_compute(aml_workspace, e.compute_name, e.vm_size)
+    if aml_compute is not None:
+        print(f"aml_compute:{aml_compute}")
+
+    # Create a reusable Azure ML environment
+    environment = get_environment(
+        aml_workspace,
+        e.aml_custom_docker_env_name,
+        create_new=e.rebuild_env,
+        enable_docker=True,
+        dockerfile=e.aml_custom_dockerfile
+    )  #
+    run_config = RunConfiguration()
+    run_config.environment = environment
+
+    if e.datastore_name:
+        datastore_name = e.datastore_name
+    else:
+        datastore_name = aml_workspace.get_default_datastore().name
+    run_config.environment.environment_variables["DATASTORE_NAME"] = datastore_name  # NOQA: E501
+
+    datastore = Datastore(aml_workspace, name=datastore_name)
+    data_file_path_param = PipelineParameter(name="data_file_path", default_value=e.dataset_name)  # NOQA: E501
+    caller_run_id_param = PipelineParameter(name="caller_run_id", default_value="none")  # NOQA: E501
+
+    # The version of the input/output dataset can't be determined at pipeline publish time, only run time.  # NOQA: E501
+    # Options to store output data:
+    # Option 1: Use blob API to write output data. Otherwise, no way to dynamically change the output dataset based on PipelineParameter, # NOQA: E501
+    #     The following will not work. It generate a path like "PipelineParameter_Name:data_file_path_Default:gear_images"  # NOQA: E501
+    #         output_ds = OutputFileDatasetConfig(destination=(datastore, data_file_path_param))  # NOQA: E501
+    #     This option means writing a file locally and upload to the datastore. Fewer dataset, more code.  # NOQA: E501
+    # Option 2: Use a dynamic path in OutputFileDatasetConfig, and register a new dataset at completion  # NOQA: E501
+    #     Output dataset can be mounted, so more dataset to maintain, less code.   # NOQA: E501
+    # Using Option 2 below.
+    output_ds = OutputFileDatasetConfig(
+        name=e.processed_dataset_name,
+        destination=(datastore, "/dataset/{output-name}/{run-id}")
+    ).register_on_complete(
+        name=e.processed_dataset_name)
+
+    preprocess_step = PythonScriptStep(
+        name="Preprocess Data with OS cmd",
+        script_name=e.preprocess_os_cmd_script_path,
+        compute_target=aml_compute,
+        source_directory=e.sources_directory_train,
+        arguments=[
+            "--dataset_name", e.dataset_name,
+            "--datastore_name", datastore_name,
+            "--data_file_path", data_file_path_param,
+            "--caller_run_id", caller_run_id_param,
+            "--step_output", output_ds,
+        ],
+        runconfig=run_config,
+        allow_reuse=False,
+    )
+    print("Step Preprocess OS cmd created")
+
+    steps = [preprocess_step]
+    preprocess_pipeline = Pipeline(workspace=aml_workspace, steps=steps)
+    preprocess_pipeline._set_experiment_name
+    preprocess_pipeline.validate()
+    published_pipeline = preprocess_pipeline.publish(
+        name=e.preprocessing_os_cmd_pipeline_name,
+        description="Data preprocessing OS cmd pipeline",
+        version=e.build_id,
+    )
+    print(f"Published pipeline: {published_pipeline.name}")
+    print(f"for build {published_pipeline.version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ml_service/pipelines/build_data_processing_os_cmd_pipeline.py
+++ b/ml_service/pipelines/build_data_processing_os_cmd_pipeline.py
@@ -27,10 +27,10 @@ def main():
     # Create a reusable Azure ML environment
     environment = get_environment(
         aml_workspace,
-        e.aml_custom_docker_env_name,
+        e.aml_preprocessing_custom_docker_env_name,
         create_new=e.rebuild_env,
         enable_docker=True,
-        dockerfile=e.aml_custom_dockerfile
+        dockerfile=e.aml_preprocessing_custom_dockerfile
     )  #
     run_config = RunConfiguration()
     run_config.environment = environment
@@ -62,7 +62,7 @@ def main():
 
     preprocess_step = PythonScriptStep(
         name="Preprocess Data with OS cmd",
-        script_name=e.preprocess_os_cmd_script_path,
+        script_name=e.preprocessing_os_cmd_script_path,
         compute_target=aml_compute,
         source_directory=e.sources_directory_train,
         arguments=[

--- a/ml_service/pipelines/run_data_processing_pipeline.py
+++ b/ml_service/pipelines/run_data_processing_pipeline.py
@@ -7,6 +7,11 @@ import argparse
 def main():
     parser = argparse.ArgumentParser("register")
     parser.add_argument(
+        "--aml_pipeline_name",
+        type=str,
+        help="Name of a the aml pipeline to retrieve ID from"
+    )
+    parser.add_argument(
         "--output_pipeline_id_file",
         type=str,
         default="preprocessing_pipeline_id.txt",
@@ -36,7 +41,7 @@ def main():
     latest_version = 0
     latest_pipe = None
     for p in pipelines:
-        if p.name == e.preprocessing_pipeline_name:
+        if p.name == args.aml_pipeline_name:
             if p.version == e.build_id:
                 matched_pipes.append(p)
             elif int(p.version) > latest_version:

--- a/ml_service/util/env_variables.py
+++ b/ml_service/util/env_variables.py
@@ -70,3 +70,7 @@ class Env:
     aml_env_name_score_copy: Optional[str] = os.environ.get("AML_ENV_NAME_SCORE_COPY")  # NOQA: E501
     batchscore_script_path: Optional[str] = os.environ.get("BATCHSCORE_SCRIPT_PATH")  # NOQA: E501
     batchscore_copy_script_path: Optional[str] = os.environ.get("BATCHSCORE_COPY_SCRIPT_PATH")  # NOQA: E501
+    aml_custom_docker_env_name: Optional[str] = os.environ.get("AML_CUSTOM_DOCKER_ENV_NAME")  # NOQA: E501
+    aml_custom_dockerfile: Optional[str] = os.environ.get("AML_CUSTOM_DOCKERFILE")  # NOQA: E501
+    preprocess_os_cmd_script_path: Optional[str] = os.environ.get("PREPROCESS_OS_CMD_SCRIPT_PATH")  # NOQA: E501
+    preprocessing_os_cmd_pipeline_name: Optional[str] = os.environ.get("PREPROCESSING_OS_CMD_PIPELINE_NAME")  # NOQA: E501

--- a/ml_service/util/env_variables.py
+++ b/ml_service/util/env_variables.py
@@ -70,7 +70,7 @@ class Env:
     aml_env_name_score_copy: Optional[str] = os.environ.get("AML_ENV_NAME_SCORE_COPY")  # NOQA: E501
     batchscore_script_path: Optional[str] = os.environ.get("BATCHSCORE_SCRIPT_PATH")  # NOQA: E501
     batchscore_copy_script_path: Optional[str] = os.environ.get("BATCHSCORE_COPY_SCRIPT_PATH")  # NOQA: E501
-    aml_custom_docker_env_name: Optional[str] = os.environ.get("AML_CUSTOM_DOCKER_ENV_NAME")  # NOQA: E501
-    aml_custom_dockerfile: Optional[str] = os.environ.get("AML_CUSTOM_DOCKERFILE")  # NOQA: E501
-    preprocess_os_cmd_script_path: Optional[str] = os.environ.get("PREPROCESS_OS_CMD_SCRIPT_PATH")  # NOQA: E501
+    aml_preprocessing_custom_docker_env_name: Optional[str] = os.environ.get("AML_PREPROCESSING_CUSTOM_DOCKER_ENV_NAME")  # NOQA: E501
+    aml_preprocessing_custom_dockerfile: Optional[str] = os.environ.get("AML_PREPROCESSING_CUSTOM_DOCKERFILE")  # NOQA: E501
+    preprocessing_os_cmd_script_path: Optional[str] = os.environ.get("PREPROCESSING_OS_CMD_SCRIPT_PATH")  # NOQA: E501
     preprocessing_os_cmd_pipeline_name: Optional[str] = os.environ.get("PREPROCESSING_OS_CMD_PIPELINE_NAME")  # NOQA: E501

--- a/ml_service/util/manage_environment.py
+++ b/ml_service/util/manage_environment.py
@@ -8,10 +8,12 @@ from azureml.core.runconfig import DEFAULT_CPU_IMAGE, DEFAULT_GPU_IMAGE
 def get_environment(
     workspace: Workspace,
     environment_name: str,
-    conda_dependencies_file: str,
+    conda_dependencies_file: str = None,
     create_new: bool = False,
     enable_docker: bool = None,
-    use_gpu: bool = False
+    docker_image: str = None,
+    dockerfile: str = None,
+    use_gpu: bool = False,
 ):
     try:
         e = Env()
@@ -22,14 +24,47 @@ def get_environment(
                 restored_environment = environments[environment_name]
 
         if restored_environment is None or create_new:
-            new_env = Environment.from_conda_specification(
-                environment_name,
-                os.path.join(e.sources_directory_train, conda_dependencies_file),  # NOQA: E501
-            )  # NOQA: E501
-            restored_environment = new_env
+
+            if restored_environment is None:
+                # Environment has to be created
+                if conda_dependencies_file is not None:
+                    new_env = Environment.from_conda_specification(
+                        environment_name,
+                        os.path.join(e.sources_directory_train, conda_dependencies_file),  # NOQA: E501
+                    )  # NOQA: E501
+                    restored_environment = new_env
+                else:
+                    restored_environment = Environment(environment_name)
+            else:
+                if conda_dependencies_file is not None:
+                    # Environment has to be updated
+                    restored_environment.conda_dependencies_file =\
+                        os.path.join(e.sources_directory_train,
+                                     conda_dependencies_file)
+
             if enable_docker is not None:
                 restored_environment.docker.enabled = enable_docker
-                restored_environment.docker.base_image = DEFAULT_GPU_IMAGE if use_gpu else DEFAULT_CPU_IMAGE  # NOQA: E501
+
+                if docker_image is not None:
+                    restored_environment.docker.base_image = docker_image
+                    # In case of own image
+                    # don't append AML managed dependencies
+                    restored_environment.python.\
+                        user_managed_dependencies = True
+                elif dockerfile is not None:
+                    # Alternatively, load from a file.
+                    with open(dockerfile, "r") as f:
+                        dockerfile = f.read()
+                        restored_environment.docker.\
+                            base_dockerfile = dockerfile
+                    # In case of own Dockerfile
+                    # don't append AML managed dependencies
+                    restored_environment.python.\
+                        user_managed_dependencies = True
+                else:
+                    restored_environment.docker.\
+                        base_image = DEFAULT_GPU_IMAGE if use_gpu else DEFAULT_CPU_IMAGE  # NOQA: E501
+
             restored_environment.register(workspace)
 
         if restored_environment is not None:

--- a/ml_service/util/manage_environment.py
+++ b/ml_service/util/manage_environment.py
@@ -25,22 +25,15 @@ def get_environment(
 
         if restored_environment is None or create_new:
 
-            if restored_environment is None:
-                # Environment has to be created
-                if conda_dependencies_file is not None:
-                    new_env = Environment.from_conda_specification(
-                        environment_name,
-                        os.path.join(e.sources_directory_train, conda_dependencies_file),  # NOQA: E501
-                    )  # NOQA: E501
-                    restored_environment = new_env
-                else:
-                    restored_environment = Environment(environment_name)
+            # Environment has to be created
+            if conda_dependencies_file is not None:
+                new_env = Environment.from_conda_specification(
+                    environment_name,
+                    os.path.join(e.sources_directory_train, conda_dependencies_file),  # NOQA: E501
+                )  # NOQA: E501
+                restored_environment = new_env
             else:
-                if conda_dependencies_file is not None:
-                    # Environment has to be updated
-                    restored_environment.conda_dependencies_file =\
-                        os.path.join(e.sources_directory_train,
-                                     conda_dependencies_file)
+                restored_environment = Environment(environment_name)
 
             if enable_docker is not None:
                 restored_environment.docker.enabled = enable_docker


### PR DESCRIPTION
Hi,

this is the base functionality required to run any linux cmd-line tool within an AML pipeline step. For now I sticked to the structure MLOpsPython provides e.g. putting all script paths as variables.

- [X] Adding custom AML Pipeline compatible plain Dockerfile
- [X] Adding AML pipeline running on custom docker and executing an OS cmd wrapper script
- [X] Adding OS cmd wrapper script `preprocess_os_cmd.py` leveraging `subprocess` to copy files from input folder to output folder
- [X] Adding new environment variables to `env.example`
- [X] Modify `util.manage_environments.py` to allow Dockerfile usage
- [X] Modify `util.manage_environments.py` to correctly update environments
- [ ] Adding unit tests to test preprocess and pipeline script --> please see #21 for direction discussion, therefore won't add unit test to this PR
- [x] Adding AzDO pipelines to verify Dockerfile
- [x] Adding AzDO pipelines to publish new AML pipeline
- [x] [Documentation](https://github.com/liupeirong/MLOpsManufacturing/blob/h2floh/12_nonpythonamlstep/ml_model/preprocessing/README.md)  on how to modify to install a tool and use it instead of `cp`

