### PR TITLE
Refactor CI: Change name's and allow updating the conda environment on runtime

### DIFF
--- a/.pipelines/01-pull-request.yml
+++ b/.pipelines/01-pull-request.yml
@@ -3,8 +3,8 @@
 resources:
   containers:
   - container: mlops
-    image: public/mlops/tensorflow:latest
-    endpoint: mlopstensorflowacr 
+    image: mlopsmanufacturing/build-agent:latest
+    endpoint: mlopsmanufacturingacr 
 
 pr:
   branches:

--- a/.pipelines/01-pull-request.yml
+++ b/.pipelines/01-pull-request.yml
@@ -3,7 +3,7 @@
 resources:
   containers:
   - container: mlops
-    image: mlopsmanufacturing/build-agent:latest
+    image: mlopsmanufacturing/build-agent/tensorflow:latest
     endpoint: mlopsmanufacturingacr 
 
 pr:

--- a/.pipelines/02-processing-data.yml
+++ b/.pipelines/02-processing-data.yml
@@ -3,8 +3,8 @@
 resources:
   containers:
   - container: mlops
-    image: public/mlops/tensorflow:latest
-    endpoint: mlopstensorflowacr
+    image: mlopsmanufacturing/build-agent:latest
+    endpoint: mlopsmanufacturingacr
 
 pr: none
 trigger:

--- a/.pipelines/02-processing-data.yml
+++ b/.pipelines/02-processing-data.yml
@@ -3,7 +3,7 @@
 resources:
   containers:
   - container: mlops
-    image: mlopsmanufacturing/build-agent:latest
+    image: mlopsmanufacturing/build-agent/tensorflow:latest
     endpoint: mlopsmanufacturingacr
 
 pr: none

--- a/.pipelines/03-train-evaluate-register-model.yml
+++ b/.pipelines/03-train-evaluate-register-model.yml
@@ -3,8 +3,8 @@
 resources:
   containers:
   - container: mlops
-    image: public/mlops/tensorflow:latest
-    endpoint: mlopstensorflowacr
+    image: mlopsmanufacturing/build-agent:latest
+    endpoint: mlopsmanufacturingacr
 
 pr: none
 trigger:

--- a/.pipelines/03-train-evaluate-register-model.yml
+++ b/.pipelines/03-train-evaluate-register-model.yml
@@ -3,8 +3,15 @@
 resources:
   containers:
   - container: mlops
-    image: mlopsmanufacturing/build-agent:latest
+    image: mlopsmanufacturing/build-agent/tensorflow:latest
     endpoint: mlopsmanufacturingacr
+  pipelines:
+  - pipeline: model-train-ci
+    source: 02-processing-data # Name of the triggering pipeline
+    trigger:
+      branches:
+        include:
+        - main
 
 pr: none
 trigger:

--- a/.pipelines/04-deploy-model-aci.yml
+++ b/.pipelines/04-deploy-model-aci.yml
@@ -11,8 +11,8 @@ parameters:
 resources:
   containers:
   - container: mlops
-    image: public/mlops/tensorflow:latest
-    endpoint: mlopstensorflowacr
+    image: mlopsmanufacturing/build-agent:latest
+    endpoint: mlopsmanufacturingacr
   pipelines:
   - pipeline: model-train-ci
     source: 03-train-evaluate-register-model # Name of the triggering pipeline

--- a/.pipelines/04-deploy-model-aci.yml
+++ b/.pipelines/04-deploy-model-aci.yml
@@ -11,7 +11,7 @@ parameters:
 resources:
   containers:
   - container: mlops
-    image: mlopsmanufacturing/build-agent:latest
+    image: mlopsmanufacturing/build-agent/tensorflow:latest
     endpoint: mlopsmanufacturingacr
   pipelines:
   - pipeline: model-train-ci

--- a/.pipelines/05-create-scoring-docker-image.yml
+++ b/.pipelines/05-create-scoring-docker-image.yml
@@ -8,8 +8,8 @@ parameters:
 resources:
   containers:
   - container: mlops
-    image: public/mlops/tensorflow:latest
-    endpoint: mlopstensorflowacr
+    image: mlopsmanufacturing/build-agent:latest
+    endpoint: mlopsmanufacturingacr
   pipelines:
   - pipeline: model-train-ci
     source: 03-train-evaluate-register-model # Name of the triggering pipeline

--- a/.pipelines/05-create-scoring-docker-image.yml
+++ b/.pipelines/05-create-scoring-docker-image.yml
@@ -8,7 +8,7 @@ parameters:
 resources:
   containers:
   - container: mlops
-    image: mlopsmanufacturing/build-agent:latest
+    image: mlopsmanufacturing/build-agent/tensorflow:latest
     endpoint: mlopsmanufacturingacr
   pipelines:
   - pipeline: model-train-ci

--- a/.pipelines/07-processing-data-os-cmd.yml
+++ b/.pipelines/07-processing-data-os-cmd.yml
@@ -3,8 +3,8 @@
 resources:
   containers:
   - container: mlops
-    image: public/mlops/tensorflow:latest
-    endpoint: mlopstensorflowacr
+    image: mlopsmanufacturing/build-agent:latest
+    endpoint: mlopsmanufacturingacr
 
 pr: none
 trigger:

--- a/.pipelines/07-processing-data-os-cmd.yml
+++ b/.pipelines/07-processing-data-os-cmd.yml
@@ -3,7 +3,7 @@
 resources:
   containers:
   - container: mlops
-    image: mlopsmanufacturing/build-agent:latest
+    image: mlopsmanufacturing/build-agent/tensorflow:latest
     endpoint: mlopsmanufacturingacr
 
 pr: none

--- a/environment_setup/Dockerfile
+++ b/environment_setup/Dockerfile
@@ -1,9 +1,6 @@
 FROM conda/miniconda3
 
-COPY ml_model/ci_dependencies.yml /setup/
-
-# activate environment
-ENV PATH /usr/local/envs/mlopstensorflow_ci/bin:$PATH
+ENV PATH /opt/conda/bin/:$PATH
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV LANGUAGE C.UTF-8
@@ -11,18 +8,17 @@ ENV LANGUAGE C.UTF-8
 RUN conda update -n base -c defaults conda && \
     conda install python=3.7.5 && \
     apt-get update && \
-    apt-get install gcc python3-dev -y && \
-    apt-get update && \
+    apt-get install gcc python3-dev -y
+
+# Install Azure CLI
+RUN apt-get update && \
     apt-get install ca-certificates curl apt-transport-https lsb-release gnupg -y && \
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null && \
     AZ_REPO=$(lsb_release -cs) && \
     echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list && \
     apt-get update && \
     apt-get install azure-cli -y && \
-    conda env create -f /setup/ci_dependencies.yml && \
-    /bin/bash -c "source activate mlopstensorflow_ci" && \
-    az --version && \
-    chmod -R 777 /usr/local/envs/mlopstensorflow_ci/lib/python3.7
+    az --version
 
 # az cli extension defaults to $HOME/.azure/cliextensions
 # which doesn't exist when running in ADO because ADO runs as 
@@ -30,3 +26,15 @@ RUN conda update -n base -c defaults conda && \
 RUN mkdir /opt/azcliextensions 
 ENV AZURE_EXTENSION_DIR /opt/azcliextensions
 RUN az extension add -n azure-cli-ml
+
+# add and activate user buildagent 
+RUN groupadd --gid 1000 buildagent && \
+    useradd -s /bin/bash --uid 1000 --gid 1000 -m buildagent
+
+USER buildagent
+
+# activate CI environment
+COPY ml_model/ci_dependencies.yml /home/buildagent/.
+
+RUN conda env create -f /home/buildagent/ci_dependencies.yml -n ci && \
+    echo "source activate ci" >> ~/.bashrc

--- a/environment_setup/Dockerfile
+++ b/environment_setup/Dockerfile
@@ -27,14 +27,14 @@ RUN mkdir /opt/azcliextensions
 ENV AZURE_EXTENSION_DIR /opt/azcliextensions
 RUN az extension add -n azure-cli-ml
 
-# add and activate user buildagent 
-RUN groupadd --gid 1000 buildagent && \
-    useradd -s /bin/bash --uid 1000 --gid 1000 -m buildagent
+# add and activate user vsts 
+RUN groupadd --gid 1001 vsts && \
+    useradd -s /bin/bash --uid 1001 --gid 1001 -m vsts
 
-USER buildagent
+USER vsts
 
 # activate CI environment
-COPY ml_model/ci_dependencies.yml /home/buildagent/.
+COPY ml_model/ci_dependencies.yml /home/vsts/.
 
-RUN conda env create -f /home/buildagent/ci_dependencies.yml -n ci && \
+RUN conda env create -f /home/vsts/ci_dependencies.yml -n ci && \
     echo "source activate ci" >> ~/.bashrc

--- a/environment_setup/Dockerfile
+++ b/environment_setup/Dockerfile
@@ -27,14 +27,17 @@ RUN mkdir /opt/azcliextensions
 ENV AZURE_EXTENSION_DIR /opt/azcliextensions
 RUN az extension add -n azure-cli-ml
 
-# add and activate user vsts 
+# precreate user vsts 
 RUN groupadd --gid 1001 vsts && \
     useradd -s /bin/bash --uid 1001 --gid 1001 -m vsts
 
 USER vsts
 
-# activate CI environment
+# precreate CI environment for user vsts
 COPY ml_model/ci_dependencies.yml /home/vsts/.
 
 RUN conda env create -f /home/vsts/ci_dependencies.yml -n ci && \
     echo "source activate ci" >> ~/.bashrc
+
+# switch back to root
+USER root

--- a/environment_setup/Dockerfile
+++ b/environment_setup/Dockerfile
@@ -36,8 +36,10 @@ USER vsts
 # precreate CI environment for user vsts
 COPY ml_model/ci_dependencies.yml /home/vsts/.
 
-RUN conda env create -f /home/vsts/ci_dependencies.yml -n ci && \
-    echo "source activate ci" >> ~/.bashrc
+RUN conda env create -f /home/vsts/ci_dependencies.yml -n ci
+
+# activate environment (Azure Pipelines won't use bash to execute)
+ENV PATH /home/vsts/.conda/envs/ci/bin:$PATH
 
 # switch back to root
 USER root

--- a/environment_setup/docker-image-pipeline.yml
+++ b/environment_setup/docker-image-pipeline.yml
@@ -13,13 +13,13 @@ trigger:
   paths:
     include:
     - environment_setup/Dockerfile
+    - ml_model/ci_dependencies.yml
 
 variables:
-- group: devopsforai-aml-vg
 - name: containerRegistry
-  value: $[coalesce(variables['acrServiceConnection'], 'acrconnection')]
+  value: mlopsmanufacturingacr
 - name: imageName
-  value: $[coalesce(variables['agentImageName'], 'public/mlops/tensorflow')]
+  value: mlopsmanufacturing/build-agent
         
 steps:
   - task: Docker@2

--- a/environment_setup/docker-image-pipeline.yml
+++ b/environment_setup/docker-image-pipeline.yml
@@ -19,7 +19,7 @@ variables:
 - name: containerRegistry
   value: mlopsmanufacturingacr
 - name: imageName
-  value: mlopsmanufacturing/build-agent
+  value: mlopsmanufacturing/build-agent/tensorflow
         
 steps:
   - task: Docker@2

--- a/ml_model/ci_dependencies.yml
+++ b/ml_model/ci_dependencies.yml
@@ -1,4 +1,4 @@
-name: mlopstensorflow_ci
+name: mlopmanufacturing_ci
 channels:
   - conda-forge
 dependencies:

--- a/ml_model/dev_dependencies.yml
+++ b/ml_model/dev_dependencies.yml
@@ -1,4 +1,4 @@
-name: mlopstensorflow_ci
+name: mlopmanufacturing_dev
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
Did some refactoring on the CI side:

* Changing repository service name (**name of the existing ACR/docker-registry service connection needs to be renamed to `mlopsmanufacturingacr` after merge** fun fact I need to have it in place for the PR check pipeline to succeed, so I attached another ACR under `mlopsmanufacturingacr` for the time being)
* Changing build-agent image name
* Do not allow variable overwrite for repository service connection name and build-agent image name, because we can not parameterize these values efficiently in the pipelines
* Change name references in the pipelines
* Change Dockerfile for build-agent to allow the environment to be updated within a pipeline run

I tested the changes on my dev environment see the successful pipeline run where `pytest-mock` is added and then used [here](https://dev.azure.com/flwagner/MLOpsManufacturing/_build/results?buildId=412&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=12f1170f-54f2-53f3-20dd-22fc7dff55f9). [Here](https://dev.azure.com/flwagner/MLOpsManufacturing/_build/results?buildId=406&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=12f1170f-54f2-53f3-20dd-22fc7dff55f9) the run results of the build-agent build from the branch to merge. 

Recommend a squash merge for this one since I went a bit back and forth to find a workable solution.