### PR TITLE
parameterize training pipeline

### DIFF
--- a/docs/variable-management.md
+++ b/docs/variable-management.md
@@ -3,21 +3,22 @@ There are many variables used in any Azure Machine Learning (AML) projects, incl
 
 # What are the different types of variables?
 
-There are 2 broad categories of variables used in a ML project.
+Broadly speaking, an ML project has the following categories of variables.
 
 ## Infrastructure variables
 Infrastructure variables define _where_ the solution runs. In Azure, this will be Azure resources such as:
-* Azure subscription
-* resource group
-* storage account
-* container registry
+* Azure Subscription
+* Resource Group
+* Azure Storage Account
+* Azure Container Registry
 * Azure ML workspace
+
 For Azure DevOps to deploy or access Azure resources, we also need to create Azure DevOps `Service Connections` and define variables that represent these Service Connections to be used in Azure DevOps pipelines.
 
 ## Application variables
 Application variables define _how_ the solutions runs. They don't necessarily change from environment to environment, but are flexible as variables rather than hardcoded in source code. For example:
-* the compute machine spec for training
-* the data store name, dataset name, and the path of the training data
+* compute machine spec for ML model training
+* AML Data Store name, Dataset name, and the path of the training data
 * the URLs of the images used for smoke testing
 
 ## Machine Learning variables
@@ -28,22 +29,22 @@ Machine Learning variables define _how_ the data should be processed and trained
 
 # Where to store the variables?
 
-Where to store the variables depends on how you expect the variables to change. For example, 
+Where to store the variables depends on how the variables change. For example, 
 * if you store them in a file that's checked into the source repo, then they can't change unless you check in a new version or create another file.
-* if you store them in Azure DevOps variable groups, then you can create multiple variable groups for multiple DevOps pipelines typically created for different environments, such as dev, test, staging, and production. However, for variables that don't need to change from environment to environment, you don't want to specify them over and over all variable groups.
+* if you store them in Azure DevOps variable groups, then you can create multiple variable groups for multiple DevOps pipelines for different environments, such as dev, test, staging, and production. However, for variables that don't need to change from environment to environment, you don't want to specify them over and over in all variable groups.
 * if you want to experiment model training with different parameters, then you need to be able to specify these parameters as you trigger the ML pipelines.
 
-> Please note the difference between *Azure DevOps pipelines* and *Azure ML pipelines*. Azure DevOps pipelines are defined as yaml and triggered upon code change. They are responsible for building, testing, and deploying code. Azure ML pipelines are used for preprocessing data, or training, evaluating, and registering ML models. They are defined in Python code and can be triggered to run from Azure DevOps pipelines, or manually or programmatically when new data arrives. 
+> Please note the difference between *Azure DevOps pipelines* and *Azure ML pipelines*. Azure DevOps pipelines are defined as yaml and triggered upon code change. They are responsible for building, testing, and deploying code, including publishing Azure ML pipelines. Azure ML pipelines are used for preprocessing data, or training, evaluating, and registering ML models. They are defined in Python code and can be triggered to run from Azure DevOps pipelines, or manually or programmatically when new data arrives outside of Azure DevOps.
 
 Here are some suggestions on where to store different types of variables:
 * Store infrastructure variables in Azure DevOps variable groups, and reference them in Azure DevOps pipelines. When you need to run the solution in a new environment, replicate the variable groups and set the variables to the new environment, then replicate the pipelines to use the new variable groups for the new environment.
-* For application variables that don't necessarily change from environment to environment, define sensible defaults in Azure DevOps variable templates so that they don't need to be specified in variable groups. Reference them in DevOps pipelines such that if specified in variable groups, their values overwrite the defaults in variable templates. 
-* Create variables for Azure ML pipelines in a way that data scientists can run them for experimentation without dependency on Azure DevOps. You can define the default values for ML varaibles in a file and have the ML code read the file if no ML pipeline parameters are presented. This way when Azure DevOps triggers ML pipelines, sensible defaults are used, and Azure DevOps can focus on ensuring the code runs rather than training an accurate model.
+* For application variables that don't necessarily change from environment to environment, define their default values in Azure DevOps variable templates so that they don't need to be specified in variable groups. Reference them in DevOps pipelines such that if specified in variable groups, their values overwrite the defaults in variable templates. 
+* Create ML variables for AML pipelines so that data scientists can run them for experimentation without dependency on Azure DevOps. You can define the default values for ML varaibles in a file and have the ML code read the file if no ML pipeline parameters are present. This way when Azure DevOps triggers ML pipelines, sensible defaults are used, and Azure DevOps can focus on ensuring the code runs rather than training an accurate model.
 * When developing on the local machine, store infrastructure and application variables in `.env`.
 * Avoid secret variables as much as possible by using Azure built-in constructs such as Managed Identity. If you must have secrets, store them in Azure Key Vault.
 
-As an example in this project,
-* common infrastructure variables required to run the samples in this project should be stored in Azure DevOps variable groups as defined [here](../common/infrastructure/README.md). They are referenced in the [infrastructure deployment pipeline](../common/infrastructure/iac-create-environment-pipeline-arm.yml#L25). 
+For example, this is how variables are managed in this project:
+* common infrastructure variables required to run the samples are stored in Azure DevOps variable groups defined [here](../common/infrastructure/README.md). They are referenced in the [infrastructure deployment pipeline](../common/infrastructure/iac-create-environment-pipeline-arm.yml#L27). 
 * additional infrastructure variables for the image-classification-tensorflow sample are defined [here](../samples/image-classification-tensorflow#cicd-in-azure-devops). They are referenced in, for example, the [train-evaluate-register DevOps pipeline](../samples/image-classification-tensorflow/devops_pipelines/03-train-evaluate-register-model.yml#L48) 
-* application variables such as the training cluster machine spec can have sensible defaults defined in [devops_pipelines/variable-template.yml](../samples/image-classification-tensorflow/devops_pipelines/variables-template.yml) so you don't have to specify all of them in variable groups, however, based on [the order they are defined in the pipeline](../samples/image-classification-tensorflow/devops_pipelines/03-train-evaluate-register-model.yml#L46), you can overwrite their values in variables-template.yml by specifying them in the variable groups.
-* for the ML variables that need to change for experimentations, define them as [ML pipeline variables](../samples/image-classification-tensorflow/ml_service/pipelines/build_training_pipeline.py#L44). The defaults for ML variables are stored in [ml_model/parameters.json](../samples/image-classification-tensorflow/ml_model/parameters.json) so that they can run in DevOps pipelines [without having to be specified in the pipeline yamls](../samples/image-classification-tensorflow/devops_pipelines/03-train-evaluate-register-model.yml#L119).
+* application variables such as the training cluster machine spec have their defaults defined in [devops_pipelines/variable-template.yml](../samples/image-classification-tensorflow/devops_pipelines/variables-template.yml) so you don't have to specify all of them in variable groups, however, based on [the order they are defined in the pipeline](../samples/image-classification-tensorflow/devops_pipelines/03-train-evaluate-register-model.yml#L46), you can overwrite their values in variables-template.yml by specifying them in the variable groups.
+* for the ML variables that need to change for experimentations, define them as [ML pipeline variables](../samples/image-classification-tensorflow/ml_service/pipelines/build_training_pipeline.py#L46). The defaults for ML variables are stored in [ml_model/parameters.json](../samples/image-classification-tensorflow/ml_model/parameters.json) so that they can run in DevOps pipelines [without having to be specified in the pipeline yamls](../samples/image-classification-tensorflow/devops_pipelines/03-train-evaluate-register-model.yml#L119).

--- a/docs/variable-management.md
+++ b/docs/variable-management.md
@@ -1,0 +1,49 @@
+# Problem Statement
+There are many variables used in any Azure Machine Learning (AML) projects, including variables for Azure resources, Azure DevOps (ADO) pipelines, AML experiments and more. There are also many different ways to store them, for example, in environment variables, ADO variable templates, ADO variable groups, or supply them directly in command line. What's the best practice to manage these variables - which variables should be store where?
+
+# What are the different types of variables?
+
+There are 2 broad categories of variables used in a ML project.
+
+## Infrastructure variables
+Infrastructure variables define _where_ the solution runs. In Azure, this will be Azure resources such as:
+* Azure subscription
+* resource group
+* storage account
+* container registry
+* Azure ML workspace
+For Azure DevOps to deploy or access Azure resources, we also need to create Azure DevOps `Service Connections` and define variables that represent these Service Connections to be used in Azure DevOps pipelines.
+
+## Application variables
+Application variables define _how_ the solutions runs. They don't necessarily change from environment to environment, but are flexible as variables rather than hardcoded in source code. For example:
+* the compute machine spec for training
+* the data store name, dataset name, and the path of the training data
+* the URLs of the images used for smoke testing
+
+## Machine Learning variables
+Machine Learning variables define _how_ the data should be processed and trained. For example, 
+* the size to which the images should be normalized to
+* the number of epochs for ML training
+* hyperparameters for ML training
+
+# Where to store the variables?
+
+Where to store the variables depends on how you expect the variables to change. For example, 
+* if you store them in a file that's checked into the source repo, then they can't change unless you check in a new version or create another file.
+* if you store them in Azure DevOps variable groups, then you can create multiple variable groups for multiple DevOps pipelines typically created for different environments, such as dev, test, staging, and production. However, for variables that don't need to change from environment to environment, you don't want to specify them over and over all variable groups.
+* if you want to experiment model training with different parameters, then you need to be able to specify these parameters as you trigger the ML pipelines.
+
+> Please note the difference between *Azure DevOps pipelines* and *Azure ML pipelines*. Azure DevOps pipelines are defined as yaml and triggered upon code change. They are responsible for building, testing, and deploying code. Azure ML pipelines are used for preprocessing data, or training, evaluating, and registering ML models. They are defined in Python code and can be triggered to run from Azure DevOps pipelines, or manually or programmatically when new data arrives. 
+
+Here are some suggestions on where to store different types of variables:
+* Store infrastructure variables in Azure DevOps variable groups, and reference them in Azure DevOps pipelines. When you need to run the solution in a new environment, replicate the variable groups and set the variables to the new environment, then replicate the pipelines to use the new variable groups for the new environment.
+* For application variables that don't necessarily change from environment to environment, define sensible defaults in Azure DevOps variable templates so that they don't need to be specified in variable groups. Reference them in DevOps pipelines such that if specified in variable groups, their values overwrite the defaults in variable templates. 
+* Create variables for Azure ML pipelines in a way that data scientists can run them for experimentation without dependency on Azure DevOps. You can define the default values for ML varaibles in a file and have the ML code read the file if no ML pipeline parameters are presented. This way when Azure DevOps triggers ML pipelines, sensible defaults are used, and Azure DevOps can focus on ensuring the code runs rather than training an accurate model.
+* When developing on the local machine, store infrastructure and application variables in `.env`.
+* Avoid secret variables as much as possible by using Azure built-in constructs such as Managed Identity. If you must have secrets, store them in Azure Key Vault.
+
+As an example in this project,
+* common infrastructure variables required to run the samples in this project should be stored in Azure DevOps variable groups as defined [here](../common/infrastructure/README.md). They are referenced in the [infrastructure deployment pipeline](../common/infrastructure/iac-create-environment-pipeline-arm.yml#L25). 
+* additional infrastructure variables for the image-classification-tensorflow sample are defined [here](../samples/image-classification-tensorflow#cicd-in-azure-devops). They are referenced in, for example, the [train-evaluate-register DevOps pipeline](../samples/image-classification-tensorflow/devops_pipelines/03-train-evaluate-register-model.yml#L48) 
+* application variables such as the training cluster machine spec can have sensible defaults defined in [devops_pipelines/variable-template.yml](../samples/image-classification-tensorflow/devops_pipelines/variables-template.yml) so you don't have to specify all of them in variable groups, however, based on [the order they are defined in the pipeline](../samples/image-classification-tensorflow/devops_pipelines/03-train-evaluate-register-model.yml#L46), you can overwrite their values in variables-template.yml by specifying them in the variable groups.
+* for the ML variables that need to change for experimentations, define them as [ML pipeline variables](../samples/image-classification-tensorflow/ml_service/pipelines/build_training_pipeline.py#L44). The defaults for ML variables are stored in [ml_model/parameters.json](../samples/image-classification-tensorflow/ml_model/parameters.json) so that they can run in DevOps pipelines [without having to be specified in the pipeline yamls](../samples/image-classification-tensorflow/devops_pipelines/03-train-evaluate-register-model.yml#L119).

--- a/samples/image-classification-tensorflow/devops_pipelines/trigger-preprocessing-pipeline.yml
+++ b/samples/image-classification-tensorflow/devops_pipelines/trigger-preprocessing-pipeline.yml
@@ -48,4 +48,4 @@ stages:
         azureSubscription: '$(WORKSPACE_SVC_CONNECTION)'
         PipelineId: '$(PREPROCESSPIPELINE_ID)'
         ExperimentName: '$(EXPERIMENT_NAME)_preprocess'
-        PipelineParameters: '"ParameterAssignments": {"data_file_path": "$(RAW_DATAFILE_PATH)", "preprocessing_param": "$(PREPROCESSING_PARAM)"}, "tags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}, "StepTags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}'
+        PipelineParameters: '"ParameterAssignments": {"data_file_path": "$(RAW_DATAFILE_PATH)"}, "tags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}, "StepTags": {"BuildId": "$(Build.BuildId)", "BuildUri": "$(BUILD_URI)"}'

--- a/samples/image-classification-tensorflow/devops_pipelines/variables-template.yml
+++ b/samples/image-classification-tensorflow/devops_pipelines/variables-template.yml
@@ -23,12 +23,6 @@ variables:
     value: "flower-training-Pipeline"
   - name: MODEL_NAME
     value: flower_classifier
-  # Set to false to disable the evaluation step in the ML pipeline and register the newly trained model unconditionally.
-  # - name: RUN_EVALUATION
-  #   value: "true"
-  # Set to false to register the model regardless of the outcome of the evaluation step in the ML pipeline.
-  - name: ALLOW_RUN_CANCEL
-    value: "false"
   # Flag to allow rebuilding the AML Environment after it was built for the first time. This enables dependency updates from conda_dependencies.yaml.
   # - name: AML_REBUILD_ENVIRONMENT
   #  value: "false"

--- a/samples/image-classification-tensorflow/devops_pipelines/variables-template.yml
+++ b/samples/image-classification-tensorflow/devops_pipelines/variables-template.yml
@@ -43,10 +43,6 @@ variables:
   - name: AML_CLUSTER_MAX_NODES
     value: 4
 
-  # AML pipelines can run outside of Azure DevOps, these parameters control AML pipeline behaviors
-  - name: PREPROCESSING_PARAM
-    value: '{\"image_size\": {\"x\": 128, \"y\": 128},\"batch_size\": 30}'
-
   # Data used for smoke testing deployed service, comma separated
   # - name: TEST_IMAGE_URLS
   #   value: url_to_sunflower_jpg,url_to_daisy_jpg

--- a/samples/image-classification-tensorflow/local_development/.env.example
+++ b/samples/image-classification-tensorflow/local_development/.env.example
@@ -42,9 +42,6 @@ AML_CLUSTER_PRIORITY = 'lowpriority'
 AML_CLUSTER_MAX_NODES = '4'
 AML_CLUSTER_MIN_NODES = '0'
 
-# AML pipelines can run outside of Azure DevOps, these parameters control AML pipeline behaviors
-PREPROCESSING_PARAM = '{\"image_size\": {\"x\": 128, \"y\": 128},\"batch_size\": 30}'
-
 # Smoke test image URLs and Classes separated by comma
 TEST_IMAGE_URLS = 'url_to_sunflowers,url_to_daisy'
 TEST_IMAGE_CLASSES = 'sunflowers,daisy'

--- a/samples/image-classification-tensorflow/local_development/.env.example
+++ b/samples/image-classification-tensorflow/local_development/.env.example
@@ -31,10 +31,6 @@ RAW_DATAFILE_PATH = 'flower_dataset_small'
 PREPROCESSING_PIPELINE_NAME = 'flower-preprocessing-pipeline'
 TRAINING_PIPELINE_NAME = 'flower-training-pipeline'
 MODEL_NAME = 'flower_classifier'
-# Run Evaluation Step in AML pipeline
-RUN_EVALUATION = 'true'
-# Set to true cancels the Azure ML pipeline run when evaluation criteria are not met.
-ALLOW_RUN_CANCEL = 'true'
 # Flag to allow rebuilding the AML Environment after it was built for the first time. This enables dependency updates from conda_dependencies.yaml.
 AML_REBUILD_ENVIRONMENT = 'false'
 

--- a/samples/image-classification-tensorflow/ml_model/parameters.json
+++ b/samples/image-classification-tensorflow/ml_model/parameters.json
@@ -10,7 +10,7 @@
     },
     "evaluation":
     {
-
+        "cancel_if_perform_worse": "true"
     },
     "registration":
     {

--- a/samples/image-classification-tensorflow/ml_service/util/env_variables.py
+++ b/samples/image-classification-tensorflow/ml_service/util/env_variables.py
@@ -28,8 +28,6 @@ class Env:
     preprocessing_pipeline_name: Optional[str] = os.environ.get("PREPROCESSING_PIPELINE_NAME")  # NOQA: E501
     training_pipeline_name: Optional[str] = os.environ.get("TRAINING_PIPELINE_NAME")  # NOQA: E501
     model_name: Optional[str] = os.environ.get("MODEL_NAME")
-    run_evaluation: Optional[str] = os.environ.get("RUN_EVALUATION", "true")  # NOQA: E501
-    allow_run_cancel: Optional[str] = os.environ.get("ALLOW_RUN_CANCEL", "true")  # NOQA: E501
     rebuild_env: Optional[bool] = os.environ.get("AML_REBUILD_ENVIRONMENT", "false").lower().strip() == "true"  # NOQA: E501
     aml_env_name: Optional[str] = os.environ.get("AML_ENV_NAME")  # NOQA: E501
     aml_env_train_conda_dep_file: Optional[str] = os.environ.get("AML_ENV_TRAIN_CONDA_DEP_FILE", "conda_dependencies.yml")  # NOQA: E501


### PR DESCRIPTION
Added variable management doc.

To be consistent with the recommendation in the doc, refactor the training pipeline to accept parameters for model training, evaluation, and registration, so that it can be run outside of Azure DevOps for experimenting different training parameters.