### PR TITLE
fix default value for AML pipeline parameter

### DIFF
--- a/samples/image-classification-tensorflow/README.md
+++ b/samples/image-classification-tensorflow/README.md
@@ -107,4 +107,4 @@ The build agent needs to run linting, unit tests, and call Azure ML SDK to publi
 
 3. Create other pipelines
 
-Create the remaining CI/CD pipelines defined in [devops_pipelines](devops_pipelines) folder. Verify or adjust their triggers if needed. By default, they are configured to trigger on pull requests, merging to main, or as dependent pipelines complete.
+Create the remaining CI/CD pipelines defined in [devops_pipelines](devops_pipelines) folder. Verify or adjust their triggers if needed. By default, only linting and unit tests are triggered for pull request validation. Data processing and model training are only triggered on merging to main.

--- a/samples/image-classification-tensorflow/ml_model/evaluate/evaluate_model.py
+++ b/samples/image-classification-tensorflow/ml_model/evaluate/evaluate_model.py
@@ -49,7 +49,7 @@ def evaluate_model_performs_better(model, run):
 
 
 def parse_ml_params(run, ml_params):
-    if ml_params is None or ml_params == "":
+    if ml_params is None or ml_params == "default":
         with open("parameters.json") as f:
             pars = json.load(f)
     else:

--- a/samples/image-classification-tensorflow/ml_model/parameters.json
+++ b/samples/image-classification-tensorflow/ml_model/parameters.json
@@ -10,7 +10,7 @@
     },
     "evaluation":
     {
-        "cancel_if_perform_worse": "true"
+        "cancel_if_perform_worse": "false"
     },
     "registration":
     {

--- a/samples/image-classification-tensorflow/ml_model/preprocess/preprocess_aml.py
+++ b/samples/image-classification-tensorflow/ml_model/preprocess/preprocess_aml.py
@@ -85,7 +85,7 @@ def main():
     is_local_run = run.id.startswith('OfflineRun')
     aml_workspace, *_ = get_aml_context(run)
 
-    if preprocessing_param is None or preprocessing_param == "":
+    if preprocessing_param is None or preprocessing_param == "default":
         with open("parameters.json") as f:
             pars = json.load(f)
             preprocessing_args = pars["preprocessing"]

--- a/samples/image-classification-tensorflow/ml_model/register/register_model.py
+++ b/samples/image-classification-tensorflow/ml_model/register/register_model.py
@@ -54,16 +54,13 @@ def find_run(experiment, run_id):
 
 
 def parse_ml_params(run, ml_params):
-    if ml_params is None or ml_params == "":
+    if ml_params is None or ml_params == "default":
         with open("parameters.json") as f:
             pars = json.load(f)
     else:
         pars = json.loads(ml_params)
     registration_args = pars["registration"]
     print(f"registration parameters {registration_args}")
-    for (k, v) in registration_args.items():
-        run.log(k, v)
-        run.parent.log(k, v)
 
     return registration_args
 

--- a/samples/image-classification-tensorflow/ml_model/train/train_aml.py
+++ b/samples/image-classification-tensorflow/ml_model/train/train_aml.py
@@ -32,7 +32,7 @@ from util.model_helper import get_or_register_dataset
 
 
 def parse_ml_params(run, ml_params):
-    if ml_params is None or ml_params == "":
+    if ml_params is None or ml_params == "default":
         with open("parameters.json") as f:
             pars = json.load(f)
     else:

--- a/samples/image-classification-tensorflow/ml_service/pipelines/build_data_processing_pipeline.py
+++ b/samples/image-classification-tensorflow/ml_service/pipelines/build_data_processing_pipeline.py
@@ -41,8 +41,9 @@ def main():
     run_config.environment.environment_variables["DATASTORE_NAME"] = datastore_name  # NOQA: E501
 
     datastore = Datastore(aml_workspace, name=datastore_name)
+    # Note that AML pipeline parameters don't take empty string as default, "" won't work  # NOQA: E501
     data_file_path_param = PipelineParameter(name="data_file_path", default_value=e.dataset_name)  # NOQA: E501
-    preprocessing_param = PipelineParameter(name="preprocessing_param", default_value="")  # NOQA: E501
+    preprocessing_param = PipelineParameter(name="preprocessing_param", default_value="default")  # NOQA: E501
 
     # The version of the input/output dataset can't be determined at pipeline publish time, only run time.  # NOQA: E501
     # Options to store output data:

--- a/samples/image-classification-tensorflow/ml_service/pipelines/build_training_pipeline.py
+++ b/samples/image-classification-tensorflow/ml_service/pipelines/build_training_pipeline.py
@@ -41,9 +41,10 @@ def main():
 
     # datastore and dataset names are fixed for this pipeline, however
     # data_file_path can be specified for registering new versions of dataset
+    # Note that AML pipeline parameters don't take empty string as default, "" won't work  # NOQA: E501
     model_name_param = PipelineParameter(name="model_name", default_value=e.model_name)  # NOQA: E501
     data_file_path_param = PipelineParameter(name="data_file_path", default_value="nopath")  # NOQA: E501
-    ml_params = PipelineParameter(name="ml_params", default_value="")  # NOQA: E501
+    ml_params = PipelineParameter(name="ml_params", default_value="default")  # NOQA: E501
 
     # Create a PipelineData to pass data between steps
     pipeline_data = PipelineData(


### PR DESCRIPTION
If you specify the default value of an AML pipeline parameter as "", the pipeline run will fail when triggered without having the parameter. But if it has some string, it will work fine. 

Also called out in README that the processing and training pipelines are triggered on PR.