### PR TITLE
Fix devcontainers configuration

### DIFF
--- a/samples/image-classification-tensorflow/.devcontainer.json
+++ b/samples/image-classification-tensorflow/.devcontainer.json
@@ -1,10 +1,10 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
-  "name": "Non Python Preprocess",
-  "context": "../",
-  "dockerFile": "./image/Dockerfile",
+  "name": "Image Classification Tensorflow",
+  "context": "../../",
+  "dockerFile": ".devcontainer/image/Dockerfile",
   "workspaceMount": "source=${localWorkspaceFolder}/../..,target=/workspace,type=bind,consistency=cached",
-  "workspaceFolder": "/workspace/samples/non-python-preprocess",
+  "workspaceFolder": "/workspace/samples/image-classification-tensorflow",
   // Set *default* container specific settings.json values on container create.
   "settings": {
     "autoDocstring.docstringFormat": "google",

--- a/samples/image-classification-tensorflow/.devcontainer/image/Dockerfile
+++ b/samples/image-classification-tensorflow/.devcontainer/image/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:18.04
 
 # Path to current sample
-ARG  SAMPLE_PATH=samples/image-classification-tensorflow
+ARG SAMPLE_PATH=samples/image-classification-tensorflow
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN apt-get update \
     netcat
 
 # Map local machines Docker GID (retrieved by dockergid.sh) to enable non-root user to use docker on local machine
-COPY .devcontainer/dockergid /tmp
+COPY $SAMPLE_PATH/.devcontainer/dockergid /tmp
 RUN DOCKER_GID=`cat /tmp/dockergid` \
     && groupadd --gid $DOCKER_GID docker
 RUN rm /tmp/dockergid
@@ -54,7 +54,7 @@ RUN apt-get autoremove -y \
 
 # set up git-prompt.sh
 WORKDIR /usr/local/bin
-COPY .devcontainer/image/git-prompt.sh .
+COPY $SAMPLE_PATH/.devcontainer/image/git-prompt.sh .
 RUN echo "source /usr/local/bin/git-prompt.sh" >> ~/.bashrc
 RUN echo "PROMPT_COMMAND='__posh_git_ps1 \"\u@\h:\w \" \"\\\$ \";'$PROMPT_COMMAND" >> ~/.bashrc
 
@@ -73,7 +73,7 @@ ENV PATH /opt/conda/bin/:$PATH
 RUN conda update conda
 
 # Add ssh-agent/ssh-add to .bashrc
-COPY .devcontainer/image/ssh-agent.sh /tmp
+COPY $SAMPLE_PATH/.devcontainer/image/ssh-agent.sh /tmp
 RUN cat /tmp/ssh-agent.sh >> ~/.bashrc \
     && rm /tmp/ssh-agent.sh
 
@@ -108,7 +108,7 @@ ENV DEBIAN_FRONTEND=dialog
 
 # Copy conda dependencies
 WORKDIR /tmp
-COPY local_development/dev_dependencies.yml .
+COPY $SAMPLE_PATH/local_development/dev_dependencies.yml .
 
 # Create conda environment for vscode user
 USER vscode

--- a/samples/non-python-preprocess/.devcontainer.json
+++ b/samples/non-python-preprocess/.devcontainer.json
@@ -1,10 +1,10 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
-  "name": "Image Classification Tensorflow",
-  "context": "../",
-  "dockerFile": "./image/Dockerfile",
+  "name": "Non Python Preprocess",
+  "context": "../../",
+  "dockerFile": ".devcontainer/image/Dockerfile",
   "workspaceMount": "source=${localWorkspaceFolder}/../..,target=/workspace,type=bind,consistency=cached",
-  "workspaceFolder": "/workspace/samples/image-classification-tensorflow",
+  "workspaceFolder": "/workspace/samples/non-python-preprocess",
   // Set *default* container specific settings.json values on container create.
   "settings": {
     "autoDocstring.docstringFormat": "google",

--- a/samples/non-python-preprocess/.devcontainer/image/Dockerfile
+++ b/samples/non-python-preprocess/.devcontainer/image/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:18.04
 
 # Path to current sample
-ARG  SAMPLE_PATH=samples/non-python-preprocess
+ARG SAMPLE_PATH=samples/non-python-preprocess
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN apt-get update \
     netcat
 
 # Map local machines Docker GID (retrieved by dockergid.sh) to enable non-root user to use docker on local machine
-COPY .devcontainer/dockergid /tmp
+COPY $SAMPLE_PATH/.devcontainer/dockergid /tmp
 RUN DOCKER_GID=`cat /tmp/dockergid` \
     && groupadd --gid $DOCKER_GID docker
 RUN rm /tmp/dockergid
@@ -54,7 +54,7 @@ RUN apt-get autoremove -y \
 
 # set up git-prompt.sh
 WORKDIR /usr/local/bin
-COPY .devcontainer/image/git-prompt.sh .
+COPY $SAMPLE_PATH/.devcontainer/image/git-prompt.sh .
 RUN echo "source /usr/local/bin/git-prompt.sh" >> ~/.bashrc
 RUN echo "PROMPT_COMMAND='__posh_git_ps1 \"\u@\h:\w \" \"\\\$ \";'$PROMPT_COMMAND" >> ~/.bashrc
 
@@ -73,7 +73,7 @@ ENV PATH /opt/conda/bin/:$PATH
 RUN conda update conda
 
 # Add ssh-agent/ssh-add to .bashrc
-COPY .devcontainer/image/ssh-agent.sh /tmp
+COPY $SAMPLE_PATH/.devcontainer/image/ssh-agent.sh /tmp
 RUN cat /tmp/ssh-agent.sh >> ~/.bashrc \
     && rm /tmp/ssh-agent.sh
 
@@ -108,7 +108,7 @@ ENV DEBIAN_FRONTEND=dialog
 
 # Copy conda dependencies
 WORKDIR /tmp
-COPY local_development/dev_dependencies.yml .
+COPY $SAMPLE_PATH/local_development/dev_dependencies.yml .
 
 # Create conda environment for vscode user
 USER vscode


### PR DESCRIPTION
- `devcontainer.json` needs to be renamed to `.devcontainer.json`
- in vscode to be able to open different devcontainers on the sample level use command `Remote-Containers: Open Container in Folder` and select the sample folder. For this the `.devcontainer.json` file needs to be located within the sample "top-level" folder

Co-authored-by: Eunji Kim <eunk@microsoft.com>
Signed-off-by: Florian Wagner <flwagner@microsoft.com>