### PR TITLE
limit pr validation to sample

### DIFF
--- a/samples/image-classification-tensorflow/devops_pipelines/01-pull-request.yml
+++ b/samples/image-classification-tensorflow/devops_pipelines/01-pull-request.yml
@@ -18,6 +18,8 @@ pr:
     include:
     - main
   paths:
+    include:
+    - samples/image-classification-tensorflow
     exclude:
     - samples/image-classification-tensorflow/.env.example
     - README.md


### PR DESCRIPTION
This pipeline unnecessarily runs on all PRs and checkins.  Limit it to its own sample.