### PR TITLE
Improve 01-pull-request.yml pipeline to reflect package changes

### DIFF
--- a/samples/non-python-preprocess/devops_pipelines/01-pull-request.yml
+++ b/samples/non-python-preprocess/devops_pipelines/01-pull-request.yml
@@ -39,6 +39,9 @@ variables:
 - group: nonpython-preprocess-aml-vg
 
 steps:
+- template: dependency-update-template.yml
+  parameters:
+    workingDirectory: ${{ parameters.workingDirectory }}
 - template: code-quality-template.yml
   parameters:
     workingDirectory: ${{ parameters.workingDirectory }}

--- a/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
+++ b/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
@@ -1,7 +1,7 @@
 # Pipeline template to update the custom docker image with latest dependencies
 steps:
 - script: |   
-   conda env update -f /home/vsts/ci_dependencies.yml
+   conda env update -f ${{ parameters.workingDirectory }}/local_development/dev_dependencies.yml
   workingDirectory: ${{ parameters.workingDirectory }}
   displayName: 'Download pip packages with latest dependency file'
 - script: |   

--- a/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
+++ b/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
@@ -3,4 +3,8 @@ steps:
 - script: |   
    conda env create -f /home/vsts/ci_dependencies.yml -n ci-latest
   workingDirectory: ${{ parameters.workingDirectory }}
-  displayName: 'Dowload pip packages with latest dependency file'
+  displayName: 'Download pip packages with latest dependency file'
+- script: |   
+   pip list
+  workingDirectory: ${{ parameters.workingDirectory }}
+  displayName: 'Show pip package list'

--- a/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
+++ b/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
@@ -1,6 +1,6 @@
 # Pipeline template to update the custom docker image with latest dependencies
 steps:
 - script: |   
-   conda env create -f /home/vsts/ci_dependencies.yml -n ci
+   conda env create -f /home/vsts/ci_dependencies.yml -n ci-latest
   workingDirectory: ${{ parameters.workingDirectory }}
-  displayName: 'Dowlonad pip packages with latest dependency file'
+  displayName: 'Dowload pip packages with latest dependency file'

--- a/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
+++ b/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
@@ -1,7 +1,7 @@
 # Pipeline template to update the custom docker image with latest dependencies
 steps:
 - script: |   
-   conda env create -f /home/vsts/ci_dependencies.yml -n ci-latest
+   conda env update -f /home/vsts/ci_dependencies.yml
   workingDirectory: ${{ parameters.workingDirectory }}
   displayName: 'Download pip packages with latest dependency file'
 - script: |   

--- a/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
+++ b/samples/non-python-preprocess/devops_pipelines/dependency-update-template.yml
@@ -1,0 +1,6 @@
+# Pipeline template to update the custom docker image with latest dependencies
+steps:
+- script: |   
+   conda env create -f /home/vsts/ci_dependencies.yml -n ci
+  workingDirectory: ${{ parameters.workingDirectory }}
+  displayName: 'Dowlonad pip packages with latest dependency file'

--- a/samples/non-python-preprocess/local_development/dev_dependencies.yml
+++ b/samples/non-python-preprocess/local_development/dev_dependencies.yml
@@ -25,5 +25,6 @@ dependencies:
       - flake8==3.7.*
       - flake8_formatter_junit_xml==0.0.*
       - debugpy
+      - easydict
 
 


### PR DESCRIPTION
### Problem statement
If you refer to a new package in your code, an error will occur at the 01-pull-request-validation step when merging into the main branch.
This is because the pip package is not installed in the custom docker image being reused.

### Solution
Whenever code is merged into the main branch, it checks if there are any changes in 'non-python-preprocess/devops_pipelines/build_agent/ci_dependencies.yml'.
If there are any changes, install the packages newly using the updated ci_dependencies.yml file in the new conda environment and proceed with the rest of the process.