### PR TITLE
Fix AzureIoTEdge task build break in edge-object-detection sample

### DIFF
--- a/samples/edge-object-detection/.pipelines/cd/iot-edge-modules.yml
+++ b/samples/edge-object-detection/.pipelines/cd/iot-edge-modules.yml
@@ -17,7 +17,7 @@ pool:
 
 variables:
 - name: pythonVersion
-  value: '3.9'
+  value: '3.7'
 # Service connection variables must be global due to issue:
 # https://developercommunity.visualstudio.com/content/problem/676259/using-a-variable-for-the-service-connection-result.html
 - name: devServiceConnection

--- a/samples/edge-object-detection/.pipelines/ci/iot-edge-modules.yml
+++ b/samples/edge-object-detection/.pipelines/ci/iot-edge-modules.yml
@@ -18,7 +18,7 @@ variables:
 - name: workingDir
   value: edge
 - name: pythonVersion
-  value: '3.9'
+  value: '3.7'
 # Service connection variables must be global due to issue:
 # https://developercommunity.visualstudio.com/content/problem/676259/using-a-variable-for-the-service-connection-result.html
 - name: devServiceConnection

--- a/samples/edge-object-detection/.pipelines/ci/lva-console-app.yml
+++ b/samples/edge-object-detection/.pipelines/ci/lva-console-app.yml
@@ -16,7 +16,7 @@ variables:
 - name: workingDir
   value: lva-console-app
 - name: pythonVersion
-  value: '3.9'
+  value: '3.7'
 
 jobs:
 - job: lva_console_app_validation

--- a/samples/edge-object-detection/.pipelines/pr/iot-edge-modules.yml
+++ b/samples/edge-object-detection/.pipelines/pr/iot-edge-modules.yml
@@ -7,7 +7,7 @@ variables:
 - name: workingDir
   value: edge
 - name: pythonVersion
-  value: '3.9'
+  value: '3.7'
 - template: ${{variables['System.DefaultWorkingDirectory']}}/.pipelines/variables/vars-dev.yml
 - name: image_tag
   value: $(build.BuildId)

--- a/samples/edge-object-detection/.pipelines/pr/lva-console-app.yml
+++ b/samples/edge-object-detection/.pipelines/pr/lva-console-app.yml
@@ -7,7 +7,7 @@ variables:
 - name: workingDir
   value: lva-console-app
 - name: pythonVersion
-  value: '3.9'
+  value: '3.7'
 
 jobs:
 - job: lva_console_app_validation

--- a/samples/edge-object-detection/.pipelines/templates/iot-build-modules.yml
+++ b/samples/edge-object-detection/.pipelines/templates/iot-build-modules.yml
@@ -1,6 +1,16 @@
 # Build IoT modules for both ARM and AMD
 
 steps:
+# This is needed because the AzureIoTEdge@2 requires iotedgedev 3.0 but fails to install it
+# It fails to install it on ubuntu 20.04 because the pip3 default there is py3.8
+# and iotedgedev 3.0 only supports python 3.7 and below.
+# We have set the python version to 3.7, but that is not respected by how the task installs iotedgedev
+- task: Bash@3
+  displayName: 'Install iotedgedev'
+  inputs:
+    targetType: 'inline'
+    script: 'pip install -U iotedgedev'
+
 - task: AzureIoTEdge@2
   displayName: 'Build module images - AMD'
   inputs:

--- a/samples/edge-object-detection/README.md
+++ b/samples/edge-object-detection/README.md
@@ -256,7 +256,7 @@ these sections will provide more information on how that can be accomplished!
 
 ### Prerequisites
 
-- [Python v3.9+](https://www.python.org/downloads/)
+- [Python v3.7](https://www.python.org/downloads/)
 - [Docker](https://www.docker.com/)
 - [Visual Studio Code](https://code.visualstudio.com/)
 - [Azure IoT Tools extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-tools)

--- a/samples/edge-object-detection/docs/dev-environment-setup.md
+++ b/samples/edge-object-detection/docs/dev-environment-setup.md
@@ -5,7 +5,7 @@ The goal of this document is to describe how to setup your development environme
 ## Sections <!-- omit in toc -->
 
 - [Python Setup](#python-setup)
-  - [Install Python (v3.9)](#install-python-v39)
+  - [Install Python (v3.7)](#install-python-v37)
   - [Virtual Environment](#virtual-environment)
     - [Setup Python virtual environment via `VirtualEnv`](#setup-python-virtual-environment-via-virtualenv)
     - [Setup Python virtual environment via `PyEnv`](#setup-python-virtual-environment-via-pyenv)
@@ -14,7 +14,7 @@ The goal of this document is to describe how to setup your development environme
 
 ## Python Setup
 
-### Install Python (v3.9)
+### Install Python (v3.7)
 
 - Windows: <https://www.python.org/downloads/windows/>
   - **For x64 machines**, install `x86-64` version of Python.
@@ -75,7 +75,7 @@ This approach is for Mac users:
 - Install pyenv virtualenv with `brew install pyenv-virtualenv`
   - You need to have `pyenv` installed first
 - Run `pyenv virtualenv`, specifying the Python version you want and the name of the virtualenv directory
-  - E.g. `pyenv virtualenv 3.9.0 my-virtual-env-3.9.0`
+  - E.g. `pyenv virtualenv 3.7.0 my-virtual-env-3.7.0`
 - To activate the environment you can run `pyenv activate <name_of_virtualenv>`
 - To deactivate `pyenv deactivate`
 

--- a/samples/edge-object-detection/edge/tests/unit-tests/test_objectDetectionBusinessLogic.py
+++ b/samples/edge-object-detection/edge/tests/unit-tests/test_objectDetectionBusinessLogic.py
@@ -8,7 +8,7 @@ import logging
 
 from testfixtures import LogCapture
 from unittest import TestCase
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, Mock
 from datetime import datetime, timedelta
 
 # Import main.py from objectDetectionBusinessLogic edge module
@@ -118,7 +118,7 @@ class TestObjectDetectedHandlerFunction():
         ({}, '1s', 0, '2020-11-24T19:22:06.912000Z', 0.9, 'apple')
     ])
     def test_object_detected_handler(self, event_dict, timeout, expected_call_count, expected_time, confidence, tag):
-        mock = AsyncMock()
+        mock = Mock()
         mock.send_message_to_output.return_value = True
 
         with LogCapture() as logs:


### PR DESCRIPTION
AzureIoTEdge released an updated version of their task from 2.4.5 to 2.4.7. The new updated version requires installing iotedgedev 3.0, which can only be done if you are using python version < 3.8. 

This PR fixes the issue by lowering out build agent to use python 3.7 instead of 3.9. Lowering the version only required one unit test change, and the rest of our code was already being built on top of 3.7, so it is ok in that capacity as well.